### PR TITLE
Pull out I/O from __init__

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,21 +3,15 @@
 default_stages: [commit, push]
 exclude: ^(fixtures/)
 repos:
-  - repo: https://github.com/asottile/seed-isort-config
-    rev: v2.2.0
-    hooks:
-    -   id: seed-isort-config
-        args: [--application-directories,./src]
-
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.7.4
+    rev: v2.11.0
     hooks:
     - id: pyupgrade
       args: [--py37-plus]
       exclude: 'external_src/int-tools'
 
   - repo: https://github.com/asottile/add-trailing-comma
-    rev: v2.0.1
+    rev: v2.1.0
     hooks:
       - id: add-trailing-comma
         args: [ --py36-plus ]

--- a/src/pyatmo/auth.py
+++ b/src/pyatmo/auth.py
@@ -108,9 +108,7 @@ class NetatmoOAuth2:
     ) -> Any:
         """Wrapper for post requests."""
         resp = None
-        req_args = {}
-
-        req_args["data"] = params if params is not None else {}
+        req_args = {"data": params if params is not None else {}}
 
         if "json" in req_args["data"]:
             req_args["json"] = req_args["data"]["json"]

--- a/src/pyatmo/camera.py
+++ b/src/pyatmo/camera.py
@@ -60,6 +60,8 @@ class CameraData:
         if not self._raw_data:
             raise NoDevice("No device data available")
 
+    def process(self) -> None:
+        """Process data from API."""
         self.homes = {d["id"]: d for d in self._raw_data}
 
         for item in self._raw_data:

--- a/src/pyatmo/camera.py
+++ b/src/pyatmo/camera.py
@@ -43,7 +43,7 @@ class CameraData:
         self.events: Dict = defaultdict(dict)
         self.outdoor_events: Dict = defaultdict(dict)
         self.cameras: Dict = defaultdict(dict)
-        self.smokedetectors: Dict = defaultdict(dict)
+        self.smoke_detectors: Dict = defaultdict(dict)
         self.modules: Dict = {}
         self.last_event: Dict = {}
         self.outdoor_last_event: Dict = {}
@@ -51,14 +51,15 @@ class CameraData:
 
     def update(self, events: int = 30) -> None:
         """Fetch and process data from API."""
-        post_params = {"size": events}
-        resp = self.auth.post_request(url=_GETHOMEDATA_REQ, params=post_params)
+        resp = self.auth.post_request(url=_GETHOMEDATA_REQ, params={"size": events})
         if resp is None or "body" not in resp:
             raise NoDevice("No device data returned by Netatmo server")
 
         self._raw_data = resp["body"].get("homes")
         if not self._raw_data:
             raise NoDevice("No device data available")
+
+        self.process()
 
     def process(self) -> None:
         """Process data from API."""
@@ -87,7 +88,7 @@ class CameraData:
                         self.modules[module["id"]]["cam_id"] = camera["id"]
 
             for smoke in item.get("smokedetectors", []):
-                self.smokedetectors[home_id][smoke["id"]] = smoke
+                self.smoke_detectors[home_id][smoke["id"]] = smoke
                 self.types[home_id][smoke["type"]] = smoke
 
         self._store_last_event()
@@ -128,9 +129,9 @@ class CameraData:
 
     def get_smokedetector(self, smoke_id: str) -> Optional[dict]:
         """Get smoke detector."""
-        for home_id in self.smokedetectors:
-            if smoke_id in self.smokedetectors[home_id]:
-                return self.smokedetectors[home_id][smoke_id]
+        for home_id in self.smoke_detectors:
+            if smoke_id in self.smoke_detectors[home_id]:
+                return self.smoke_detectors[home_id][smoke_id]
 
         return None
 

--- a/src/pyatmo/public_data.py
+++ b/src/pyatmo/public_data.py
@@ -52,20 +52,34 @@ class PublicData:
             NoDevice: No devices found.
         """
         self.auth = auth
+        self.required_data_type = required_data_type
+        self.lat_ne: str = lat_ne
+        self.lon_ne: str = lon_ne
+        self.lat_sw: str = lat_sw
+        self.lon_sw: str = lon_sw
+        self.filtering: bool = filtering
+
+        self._raw_data: dict = {}
+        self.status: str = ""
+        self.time_exec: str = ""
+        self.time_server: str = ""
+
+    def update(self) -> None:
+        """Fetch and process data from API."""
         post_params: Dict = {
-            "lat_ne": lat_ne,
-            "lon_ne": lon_ne,
-            "lat_sw": lat_sw,
-            "lon_sw": lon_sw,
-            "filter": filtering,
+            "lat_ne": self.lat_ne,
+            "lon_ne": self.lon_ne,
+            "lat_sw": self.lat_sw,
+            "lon_sw": self.lon_sw,
+            "filter": self.filtering,
         }
 
-        if required_data_type:
-            post_params["required_data"] = required_data_type
+        if self.required_data_type:
+            post_params["required_data"] = self.required_data_type
 
         resp = self.auth.post_request(url=_GETPUBLIC_DATA, params=post_params)
         try:
-            self.raw_data = resp["body"]
+            self._raw_data = resp["body"]
         except (KeyError, TypeError) as exc:
             raise NoDevice("No public weather data returned by Netatmo server") from exc
 
@@ -74,7 +88,7 @@ class PublicData:
         self.time_server = to_time_string(resp["time_server"])
 
     def stations_in_area(self) -> int:
-        return len(self.raw_data)
+        return len(self._raw_data)
 
     def get_latest_rain(self) -> Dict:
         return self.get_accessory_data(_ACCESSORY_RAIN_LIVE_TYPE)
@@ -132,7 +146,7 @@ class PublicData:
 
     def get_locations(self) -> Dict:
         locations: Dict = {}
-        for station in self.raw_data:
+        for station in self._raw_data:
             locations[station["_id"]] = station["place"]["location"]
 
         return locations
@@ -145,7 +159,7 @@ class PublicData:
 
     def get_latest_station_measures(self, data_type) -> Dict:
         measures: Dict = {}
-        for station in self.raw_data:
+        for station in self._raw_data:
             for module in station["measures"].values():
                 if (
                     "type" in module
@@ -163,7 +177,7 @@ class PublicData:
 
     def get_accessory_data(self, data_type: str) -> Dict[str, Any]:
         data: Dict = {}
-        for station in self.raw_data:
+        for station in self._raw_data:
             for module in station["measures"].values():
                 if data_type in module:
                     data[station["_id"]] = module[data_type]

--- a/src/pyatmo/public_data.py
+++ b/src/pyatmo/public_data.py
@@ -1,3 +1,4 @@
+import dataclasses
 from typing import Any, Dict
 
 from .auth import NetatmoOAuth2
@@ -19,6 +20,18 @@ _ACCESSORY_WIND_ANGLE_TYPE = "wind_angle"
 _ACCESSORY_WIND_TIME_TYPE = "wind_timeutc"
 _ACCESSORY_GUST_STRENGTH_TYPE = "gust_strength"
 _ACCESSORY_GUST_ANGLE_TYPE = "gust_angle"
+
+
+@dataclasses.dataclass
+class Location:
+    """
+    Class of Netatmo public weather location.
+    """
+
+    lat_ne: str
+    lon_ne: str
+    lat_sw: str
+    lon_sw: str
 
 
 class PublicData:
@@ -53,10 +66,7 @@ class PublicData:
         """
         self.auth = auth
         self.required_data_type = required_data_type
-        self.lat_ne: str = lat_ne
-        self.lon_ne: str = lon_ne
-        self.lat_sw: str = lat_sw
-        self.lon_sw: str = lon_sw
+        self.location = Location(lat_ne, lon_ne, lat_sw, lon_sw)
         self.filtering: bool = filtering
 
         self._raw_data: dict = {}
@@ -67,10 +77,7 @@ class PublicData:
     def update(self) -> None:
         """Fetch and process data from API."""
         post_params: Dict = {
-            "lat_ne": self.lat_ne,
-            "lon_ne": self.lon_ne,
-            "lat_sw": self.lat_sw,
-            "lon_sw": self.lon_sw,
+            **dataclasses.asdict(self.location),
             "filter": self.filtering,
         }
 
@@ -145,11 +152,9 @@ class PublicData:
         return self.get_accessory_data(_ACCESSORY_GUST_ANGLE_TYPE)
 
     def get_locations(self) -> Dict:
-        locations: Dict = {}
-        for station in self._raw_data:
-            locations[station["_id"]] = station["place"]["location"]
-
-        return locations
+        return {
+            station["_id"]: station["place"]["location"] for station in self._raw_data
+        }
 
     def get_time_for_rain_measures(self) -> Dict:
         return self.get_accessory_data(_ACCESSORY_RAIN_TIME_TYPE)

--- a/src/pyatmo/thermostat.py
+++ b/src/pyatmo/thermostat.py
@@ -50,6 +50,8 @@ class HomeData:
         if not self._raw_data:
             raise NoDevice("No thermostat data available")
 
+        self.process()
+
     def process(self) -> None:
         """Process data from API."""
         self.homes = {d["id"]: d for d in self._raw_data}
@@ -153,6 +155,8 @@ class HomeStatus:
             raise NoDevice("No device found, errors in response")
 
         self._raw_data = resp["body"]["home"]
+
+        self.process()
 
     def process(self) -> None:
         """Process data from API."""

--- a/src/pyatmo/thermostat.py
+++ b/src/pyatmo/thermostat.py
@@ -31,23 +31,28 @@ class HomeData:
             NoDevice: No devices found.
         """
         self.auth = auth
-        resp = self.auth.post_request(url=_GETHOMESDATA_REQ)
-        if resp is None or "body" not in resp:
-            raise NoDevice("No thermostat data returned by Netatmo server")
 
-        self.raw_data = resp["body"].get("homes")
-        if not self.raw_data:
-            raise NoDevice("No thermostat data available")
-
-        self.homes: Dict = {d["id"]: d for d in self.raw_data}
-
+        self._raw_data: Dict = defaultdict(dict)
+        self.homes: Dict = defaultdict(dict)
         self.modules: Dict = defaultdict(dict)
         self.rooms: Dict = defaultdict(dict)
         self.schedules: Dict = defaultdict(dict)
         self.zones: Dict = defaultdict(dict)
         self.setpoint_duration: Dict = defaultdict(dict)
 
-        for item in self.raw_data:
+    def update(self) -> None:
+        """Fetch and process data from API."""
+        resp = self.auth.post_request(url=_GETHOMESDATA_REQ)
+        if resp is None or "body" not in resp:
+            raise NoDevice("No thermostat data returned by Netatmo server")
+
+        self._raw_data = resp["body"].get("homes")
+        if not self._raw_data:
+            raise NoDevice("No thermostat data available")
+
+        self.homes = {d["id"]: d for d in self._raw_data}
+
+        for item in self._raw_data:
             home_id = item.get("id")
             home_name = item.get("name")
 
@@ -124,6 +129,15 @@ class HomeStatus:
         self.auth = auth
 
         self.home_id = home_id
+
+        self._raw_data: Dict = defaultdict(dict)
+        self.rooms: Dict = defaultdict(dict)
+        self.thermostats: Dict = defaultdict(dict)
+        self.valves: Dict = defaultdict(dict)
+        self.relays: Dict = defaultdict(dict)
+
+    def update(self) -> None:
+        """Fetch and process data from API."""
         post_params = {"home_id": self.home_id}
 
         resp = self.auth.post_request(url=_GETHOMESTATUS_REQ, params=post_params)
@@ -136,16 +150,12 @@ class HomeStatus:
             LOG.error("Errors in response: %s", resp)
             raise NoDevice("No device found, errors in response")
 
-        self.raw_data = resp["body"]["home"]
-        self.rooms: Dict = {}
-        self.thermostats: Dict = defaultdict(dict)
-        self.valves: Dict = defaultdict(dict)
-        self.relays: Dict = defaultdict(dict)
+        self._raw_data = resp["body"]["home"]
 
-        for room in self.raw_data.get("rooms", []):
+        for room in self._raw_data.get("rooms", []):
             self.rooms[room["id"]] = room
 
-        for module in self.raw_data.get("modules", []):
+        for module in self._raw_data.get("modules", []):
             if module["type"] == "NATherm1":
                 self.thermostats[module["id"]] = module
 

--- a/src/pyatmo/thermostat.py
+++ b/src/pyatmo/thermostat.py
@@ -50,6 +50,8 @@ class HomeData:
         if not self._raw_data:
             raise NoDevice("No thermostat data available")
 
+    def process(self) -> None:
+        """Process data from API."""
         self.homes = {d["id"]: d for d in self._raw_data}
 
         for item in self._raw_data:
@@ -152,6 +154,8 @@ class HomeStatus:
 
         self._raw_data = resp["body"]["home"]
 
+    def process(self) -> None:
+        """Process data from API."""
         for room in self._raw_data.get("rooms", []):
             self.rooms[room["id"]] = room
 

--- a/src/pyatmo/weather_station.py
+++ b/src/pyatmo/weather_station.py
@@ -32,7 +32,7 @@ class WeatherStationData:
         self.modules = defaultdict(dict)
 
     def update(self):
-        """Fetch and process data from API."""
+        """Fetch data from API."""
         resp = self.auth.post_request(url=self.url_req)
 
         if resp is None or "body" not in resp:
@@ -49,6 +49,8 @@ class WeatherStationData:
         if not self._raw_data:
             raise NoDevice("No weather station available")
 
+    def process(self) -> None:
+        """Process data from API."""
         self.stations = {d["_id"]: d for d in self._raw_data}
         self.modules = {}
 

--- a/src/pyatmo/weather_station.py
+++ b/src/pyatmo/weather_station.py
@@ -49,6 +49,8 @@ class WeatherStationData:
         if not self._raw_data:
             raise NoDevice("No weather station available")
 
+        self.process()
+
     def process(self) -> None:
         """Process data from API."""
         self.stations = {d["_id"]: d for d in self._raw_data}
@@ -171,7 +173,6 @@ class WeatherStationData:
         """Return data for a given station and time frame."""
         key = "_id"
 
-        # Breaking change from Netatmo : dashboard_data no longer available if station lost
         last_data: Dict = {}
         station = self.get_station(station_id)
 

--- a/src/pyatmo/weather_station.py
+++ b/src/pyatmo/weather_station.py
@@ -32,7 +32,7 @@ class WeatherStationData:
         self.modules = defaultdict(dict)
 
     def update(self):
-        """Update data."""
+        """Fetch and process data from API."""
         resp = self.auth.post_request(url=self.url_req)
 
         if resp is None or "body" not in resp:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,6 +42,7 @@ def home_data(auth, requests_mock):
     )
     home_data = pyatmo.HomeData(auth)
     home_data.update()
+    home_data.process()
     return home_data
 
 
@@ -56,6 +57,7 @@ def home_status(auth, home_id, requests_mock):
     )
     home_status = pyatmo.HomeStatus(auth, home_id)
     home_status.update()
+    home_status.process()
     return home_status
 
 
@@ -90,6 +92,7 @@ def weather_station_data(auth, requests_mock):
     )
     wsd = pyatmo.WeatherStationData(auth)
     wsd.update()
+    wsd.process()
     return wsd
 
 
@@ -104,6 +107,7 @@ def home_coach_data(auth, requests_mock):
     )
     hcd = pyatmo.HomeCoachData(auth)
     hcd.update()
+    hcd.process()
     return hcd
 
 
@@ -139,4 +143,5 @@ def camera_home_data(auth, requests_mock):
     )
     camera_data = pyatmo.CameraData(auth)
     camera_data.update()
+    camera_data.process()
     return camera_data

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,7 +82,9 @@ def weather_station_data(auth, requests_mock):
         json=json_fixture,
         headers={"content-type": "application/json"},
     )
-    return pyatmo.WeatherStationData(auth)
+    wsd = pyatmo.WeatherStationData(auth)
+    wsd.update()
+    return wsd
 
 
 @pytest.fixture(scope="function")
@@ -94,7 +96,9 @@ def home_coach_data(auth, requests_mock):
         json=json_fixture,
         headers={"content-type": "application/json"},
     )
-    return pyatmo.HomeCoachData(auth)
+    hcd = pyatmo.HomeCoachData(auth)
+    hcd.update()
+    return hcd
 
 
 @pytest.fixture(scope="function")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,7 +42,6 @@ def home_data(auth, requests_mock):
     )
     home_data = pyatmo.HomeData(auth)
     home_data.update()
-    home_data.process()
     return home_data
 
 
@@ -57,7 +56,6 @@ def home_status(auth, home_id, requests_mock):
     )
     home_status = pyatmo.HomeStatus(auth, home_id)
     home_status.update()
-    home_status.process()
     return home_status
 
 
@@ -92,7 +90,6 @@ def weather_station_data(auth, requests_mock):
     )
     wsd = pyatmo.WeatherStationData(auth)
     wsd.update()
-    wsd.process()
     return wsd
 
 
@@ -107,7 +104,6 @@ def home_coach_data(auth, requests_mock):
     )
     hcd = pyatmo.HomeCoachData(auth)
     hcd.update()
-    hcd.process()
     return hcd
 
 
@@ -143,5 +139,4 @@ def camera_home_data(auth, requests_mock):
     )
     camera_data = pyatmo.CameraData(auth)
     camera_data.update()
-    camera_data.process()
     return camera_data

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,12 +69,14 @@ def public_data(auth, requests_mock):
         headers={"content-type": "application/json"},
     )
 
-    lon_ne = 6.221652
-    lat_ne = 46.610870
-    lon_sw = 6.217828
-    lat_sw = 46.596485
+    lon_ne = str(6.221652)
+    lat_ne = str(46.610870)
+    lon_sw = str(6.217828)
+    lat_sw = str(46.596485)
 
-    return pyatmo.PublicData(auth, lat_ne, lon_ne, lat_sw, lon_sw)
+    public_data = pyatmo.PublicData(auth, lat_ne, lon_ne, lat_sw, lon_sw)
+    public_data.update()
+    return public_data
 
 
 @pytest.fixture(scope="function")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,7 +40,9 @@ def home_data(auth, requests_mock):
         json=json_fixture,
         headers={"content-type": "application/json"},
     )
-    return pyatmo.HomeData(auth)
+    home_data = pyatmo.HomeData(auth)
+    home_data.update()
+    return home_data
 
 
 @pytest.fixture(scope="function")
@@ -52,7 +54,9 @@ def home_status(auth, home_id, requests_mock):
         json=json_fixture,
         headers={"content-type": "application/json"},
     )
-    return pyatmo.HomeStatus(auth, home_id)
+    home_status = pyatmo.HomeStatus(auth, home_id)
+    home_status.update()
+    return home_status
 
 
 @pytest.fixture(scope="function")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -131,4 +131,6 @@ def camera_home_data(auth, requests_mock):
         json=json_fixture,
         headers={"content-type": "application/json"},
     )
-    return pyatmo.CameraData(auth)
+    camera_data = pyatmo.CameraData(auth)
+    camera_data.update()
+    return camera_data

--- a/tests/test_pyatmo_camera.py
+++ b/tests/test_pyatmo_camera.py
@@ -25,6 +25,7 @@ def test_home_data_no_body(auth, requests_mock):
     with pytest.raises(pyatmo.NoDevice):
         camera_data = pyatmo.CameraData(auth)
         camera_data.update()
+        camera_data.process()
 
 
 def test_home_data_no_homes(auth, requests_mock):
@@ -38,6 +39,7 @@ def test_home_data_no_homes(auth, requests_mock):
     with pytest.raises(pyatmo.NoDevice):
         camera_data = pyatmo.CameraData(auth)
         camera_data.update()
+        camera_data.process()
 
 
 @pytest.mark.parametrize(
@@ -107,6 +109,7 @@ def test_camera_data_camera_urls_disconnected(auth, requests_mock):
     )
     camera_data = pyatmo.CameraData(auth)
     camera_data.update()
+    camera_data.process()
     cid = "12:34:56:00:f1:62"
 
     camera_data.update_camera_urls(cid)
@@ -148,8 +151,6 @@ def test_camera_data_person_seen_by_camera(
 
 def test_camera_data__known_persons(camera_home_data):
     known_persons = camera_home_data._known_persons()
-    print(known_persons)
-    print(known_persons.keys())
     assert len(known_persons) == 3
     assert known_persons["91827374-7e04-5298-83ad-a0cb8372dff1"]["pseudo"] == "John Doe"
 

--- a/tests/test_pyatmo_camera.py
+++ b/tests/test_pyatmo_camera.py
@@ -25,7 +25,6 @@ def test_home_data_no_body(auth, requests_mock):
     with pytest.raises(pyatmo.NoDevice):
         camera_data = pyatmo.CameraData(auth)
         camera_data.update()
-        camera_data.process()
 
 
 def test_home_data_no_homes(auth, requests_mock):
@@ -39,7 +38,6 @@ def test_home_data_no_homes(auth, requests_mock):
     with pytest.raises(pyatmo.NoDevice):
         camera_data = pyatmo.CameraData(auth)
         camera_data.update()
-        camera_data.process()
 
 
 @pytest.mark.parametrize(
@@ -109,7 +107,6 @@ def test_camera_data_camera_urls_disconnected(auth, requests_mock):
     )
     camera_data = pyatmo.CameraData(auth)
     camera_data.update()
-    camera_data.process()
     cid = "12:34:56:00:f1:62"
 
     camera_data.update_camera_urls(cid)

--- a/tests/test_pyatmo_camera.py
+++ b/tests/test_pyatmo_camera.py
@@ -23,7 +23,8 @@ def test_home_data_no_body(auth, requests_mock):
         headers={"content-type": "application/json"},
     )
     with pytest.raises(pyatmo.NoDevice):
-        assert pyatmo.CameraData(auth)
+        camera_data = pyatmo.CameraData(auth)
+        camera_data.update()
 
 
 def test_home_data_no_homes(auth, requests_mock):
@@ -35,7 +36,8 @@ def test_home_data_no_homes(auth, requests_mock):
         headers={"content-type": "application/json"},
     )
     with pytest.raises(pyatmo.NoDevice):
-        assert pyatmo.CameraData(auth)
+        camera_data = pyatmo.CameraData(auth)
+        camera_data.update()
 
 
 @pytest.mark.parametrize(
@@ -104,6 +106,7 @@ def test_camera_data_camera_urls_disconnected(auth, requests_mock):
         headers={"content-type": "application/json"},
     )
     camera_data = pyatmo.CameraData(auth)
+    camera_data.update()
     cid = "12:34:56:00:f1:62"
 
     camera_data.update_camera_urls(cid)
@@ -253,7 +256,7 @@ def test_camera_data_set_persons_home(
 
 @freeze_time("2019-06-16")
 @pytest.mark.parametrize(
-    "camera_id, exclude, expected,expectation",
+    "camera_id, exclude, expected, expectation",
     [
         ("12:34:56:00:f1:62", None, True, does_not_raise()),
         ("12:34:56:00:f1:62", 5, False, does_not_raise()),
@@ -348,14 +351,7 @@ def test_camera_data_get_smokedetector(camera_home_data, sid, expected):
             "camera_set_state_ok.json",
             True,
         ),
-        (
-            None,
-            "12:34:56:00:f1:62",
-            None,
-            "on",
-            "camera_set_state_ok.json",
-            True,
-        ),
+        (None, "12:34:56:00:f1:62", None, "on", "camera_set_state_ok.json", True),
         (
             "91763b24c43d3e344f424e8b",
             "12:34:56:00:f1:62",

--- a/tests/test_pyatmo_homecoach.py
+++ b/tests/test_pyatmo_homecoach.py
@@ -64,4 +64,5 @@ def test_home_coach_data_no_devices(auth, requests_mock):
         headers={"content-type": "application/json"},
     )
     with pytest.raises(pyatmo.NoDevice):
-        assert pyatmo.home_coach.HomeCoachData(auth)
+        hcd = pyatmo.home_coach.HomeCoachData(auth)
+        hcd.update()

--- a/tests/test_pyatmo_publicdata.py
+++ b/tests/test_pyatmo_publicdata.py
@@ -22,6 +22,7 @@ def test_public_data(auth, requests_mock):
     )
 
     public_data = pyatmo.PublicData(auth, LAT_NE, LON_NE, LAT_SW, LON_SW)
+    public_data.update()
     assert public_data.status == "ok"
 
     public_data = pyatmo.PublicData(
@@ -32,13 +33,15 @@ def test_public_data(auth, requests_mock):
         LON_SW,
         required_data_type="temperature,rain_live",
     )
+    public_data.update()
     assert public_data.status == "ok"
 
 
 def test_public_data_unavailable(auth, requests_mock):
     requests_mock.post(pyatmo.public_data._GETPUBLIC_DATA, status_code=404)
     with pytest.raises(pyatmo.ApiError):
-        pyatmo.PublicData(auth, LAT_NE, LON_NE, LAT_SW, LON_SW)
+        public_data = pyatmo.PublicData(auth, LAT_NE, LON_NE, LAT_SW, LON_SW)
+        public_data.update()
 
 
 def test_public_data_error(auth, requests_mock):
@@ -50,7 +53,8 @@ def test_public_data_error(auth, requests_mock):
         headers={"content-type": "application/json"},
     )
     with pytest.raises(pyatmo.NoDevice):
-        pyatmo.PublicData(auth, LAT_NE, LON_NE, LAT_SW, LON_SW)
+        public_data = pyatmo.PublicData(auth, LAT_NE, LON_NE, LAT_SW, LON_SW)
+        public_data.update()
 
 
 def test_public_data_stations_in_area(public_data):

--- a/tests/test_pyatmo_thermostat.py
+++ b/tests/test_pyatmo_thermostat.py
@@ -60,7 +60,8 @@ def test_home_data(home_data):
 def test_home_data_no_data(auth, requests_mock):
     requests_mock.post(pyatmo.thermostat._GETHOMESDATA_REQ, text="None")
     with pytest.raises(pyatmo.NoDevice):
-        assert pyatmo.HomeData(auth)
+        home_data = pyatmo.HomeData(auth)
+        home_data.update()
 
 
 def test_home_data_no_body(auth, requests_mock):
@@ -72,7 +73,8 @@ def test_home_data_no_body(auth, requests_mock):
         headers={"content-type": "application/json"},
     )
     with pytest.raises(pyatmo.NoDevice):
-        assert pyatmo.HomeData(auth)
+        home_data = pyatmo.HomeData(auth)
+        home_data.update()
 
 
 def test_home_data_no_homes(auth, requests_mock):
@@ -84,7 +86,8 @@ def test_home_data_no_homes(auth, requests_mock):
         headers={"content-type": "application/json"},
     )
     with pytest.raises(pyatmo.NoDevice):
-        assert pyatmo.HomeData(auth)
+        home_data = pyatmo.HomeData(auth)
+        home_data.update()
 
 
 def test_home_data_no_home_name(auth, requests_mock):
@@ -96,6 +99,7 @@ def test_home_data_no_home_name(auth, requests_mock):
         headers={"content-type": "application/json"},
     )
     home_data = pyatmo.HomeData(auth)
+    home_data.update()
     home_id = "91763b24c43d3e344f424e8b"
     assert home_data.homes.get(home_id)["name"] == "Unknown"
 
@@ -205,6 +209,7 @@ def test_home_status_error_and_data(auth, requests_mock):
         headers={"content-type": "application/json"},
     )
     home_status = pyatmo.HomeStatus(auth, home_id="91763b24c43d3e344f424e8b")
+    home_status.update()
     assert len(home_status.rooms) == 3
 
     expexted = {
@@ -235,7 +240,8 @@ def test_home_status_error(auth, requests_mock):
         headers={"content-type": "application/json"},
     )
     with pytest.raises(pyatmo.NoDevice):
-        assert pyatmo.HomeStatus(auth, home_id="91763b24c43d3e344f424e8b")
+        home_status = pyatmo.HomeStatus(auth, home_id="91763b24c43d3e344f424e8b")
+        home_status.update()
 
 
 @pytest.mark.parametrize("home_id", ["91763b24c43d3e344f424e8b"])
@@ -571,4 +577,5 @@ def test_home_status_error_disconnected(
         headers={"content-type": "application/json"},
     )
     with pytest.raises(pyatmo.NoDevice):
-        pyatmo.HomeStatus(auth, home_id)
+        home_status = pyatmo.HomeStatus(auth, home_id)
+        home_status.update()

--- a/tests/test_pyatmo_thermostat.py
+++ b/tests/test_pyatmo_thermostat.py
@@ -100,6 +100,7 @@ def test_home_data_no_home_name(auth, requests_mock):
     )
     home_data = pyatmo.HomeData(auth)
     home_data.update()
+    home_data.process()
     home_id = "91763b24c43d3e344f424e8b"
     assert home_data.homes.get(home_id)["name"] == "Unknown"
 
@@ -210,6 +211,7 @@ def test_home_status_error_and_data(auth, requests_mock):
     )
     home_status = pyatmo.HomeStatus(auth, home_id="91763b24c43d3e344f424e8b")
     home_status.update()
+    home_status.process()
     assert len(home_status.rooms) == 3
 
     expexted = {

--- a/tests/test_pyatmo_thermostat.py
+++ b/tests/test_pyatmo_thermostat.py
@@ -100,7 +100,6 @@ def test_home_data_no_home_name(auth, requests_mock):
     )
     home_data = pyatmo.HomeData(auth)
     home_data.update()
-    home_data.process()
     home_id = "91763b24c43d3e344f424e8b"
     assert home_data.homes.get(home_id)["name"] == "Unknown"
 
@@ -211,7 +210,6 @@ def test_home_status_error_and_data(auth, requests_mock):
     )
     home_status = pyatmo.HomeStatus(auth, home_id="91763b24c43d3e344f424e8b")
     home_status.update()
-    home_status.process()
     assert len(home_status.rooms) == 3
 
     expexted = {

--- a/tests/test_pyatmo_weatherstation.py
+++ b/tests/test_pyatmo_weatherstation.py
@@ -18,7 +18,8 @@ def test_weather_station_data(weather_station_data):
 def test_weather_station_data_no_response(auth, requests_mock):
     requests_mock.post(pyatmo.weather_station._GETSTATIONDATA_REQ, text="None")
     with pytest.raises(pyatmo.NoDevice):
-        assert pyatmo.WeatherStationData(auth)
+        wsd = pyatmo.WeatherStationData(auth)
+        wsd.update()
 
 
 def test_weather_station_data_no_body(auth, requests_mock):
@@ -30,7 +31,8 @@ def test_weather_station_data_no_body(auth, requests_mock):
         headers={"content-type": "application/json"},
     )
     with pytest.raises(pyatmo.NoDevice):
-        assert pyatmo.WeatherStationData(auth)
+        wsd = pyatmo.WeatherStationData(auth)
+        wsd.update()
 
 
 def test_weather_station_data_no_data(auth, requests_mock):
@@ -42,7 +44,8 @@ def test_weather_station_data_no_data(auth, requests_mock):
         headers={"content-type": "application/json"},
     )
     with pytest.raises(pyatmo.NoDevice):
-        assert pyatmo.WeatherStationData(auth)
+        wsd = pyatmo.WeatherStationData(auth)
+        wsd.update()
 
 
 @pytest.mark.parametrize(
@@ -59,10 +62,7 @@ def test_weather_station_data_no_data(auth, requests_mock):
                 "Yard",
             ],
         ),
-        (
-            "12:34:56:36:fd:3c",
-            ["Module", "NAMain", "Rain Gauge"],
-        ),
+        ("12:34:56:36:fd:3c", ["Module", "NAMain", "Rain Gauge"]),
         pytest.param(
             "NoValidStation",
             None,
@@ -79,10 +79,7 @@ def test_weather_station_get_module_names(weather_station_data, station_id, expe
 @pytest.mark.parametrize(
     "station_id, expected",
     [
-        (
-            None,
-            {},
-        ),
+        (None, {}),
         (
             "12:34:56:37:11:ca",
             {
@@ -303,11 +300,7 @@ def test_weather_station_get_monitored_conditions(
 @pytest.mark.parametrize(
     "station_id, exclude, expected",
     [
-        (
-            "12:34:56:05:51:20",
-            None,
-            {},
-        ),
+        ("12:34:56:05:51:20", None, {}),
         (
             "12:34:56:37:11:ca",
             None,
@@ -376,11 +369,7 @@ def test_weather_station_get_last_data(
                 "12:34:56:37:11:ca",
             ],
         ),
-        (
-            "12:34:56:37:11:ca",
-            798500,
-            [],
-        ),
+        ("12:34:56:37:11:ca", 798500, []),
         pytest.param(
             "NoValidStation",
             3600,
@@ -415,11 +404,7 @@ def test_weather_station_check_not_updated(
                 "12:34:56:37:11:ca",
             ],
         ),
-        (
-            "12:34:56:37:11:ca",
-            100,
-            [],
-        ),
+        ("12:34:56:37:11:ca", 100, []),
     ],
 )
 def test_weather_station_check_updated(
@@ -493,16 +478,8 @@ def test_weather_station_get_last_data_measurements(weather_station_data):
                 "12:34:56:37:11:ca",
             ],
         ),
-        (
-            None,
-            None,
-            {},
-        ),
-        (
-            "12:34:56:00:aa:01",
-            None,
-            {},
-        ),
+        (None, None, {}),
+        ("12:34:56:00:aa:01", None, {}),
     ],
 )
 def test_weather_station_get_last_data_bug_97(

--- a/usage.md
+++ b/usage.md
@@ -1,16 +1,12 @@
-Python Netatmo API programmers guide
-------------------------------------
+## Python Netatmo API programmers guide
 
+> 2013-01-21, philippelt@users.sourceforge.net
 
+> 2014-01-13, Revision to include new modules additionnal informations
 
->2013-01-21, philippelt@users.sourceforge.net
+> 2016-06-25 Update documentation for Netatmo Welcome
 
->2014-01-13, Revision to include new modules additionnal informations
-
->2016-06-25 Update documentation for Netatmo Welcome
-
->2016-12-09 Update documentation for all Netatmo cameras
-
+> 2016-12-09 Update documentation for all Netatmo cameras
 
 No additional library other than standard Python 3 library is required.
 
@@ -18,25 +14,16 @@ More information about the Netatmo REST API can be obtained from http://dev.neta
 
 This package support only user based authentication.
 
-
-
-### 1 Setup your environment from Netatmo Web interface ###
-
-
-
+### 1 Setup your environment from Netatmo Web interface
 
 Before being able to use the module you will need :
 
-  * A Netatmo user account having access to, at least, one station
-  * An application registered from the user account (see http://dev.netatmo.com/dev/createapp) to obtain application credentials.
+- A Netatmo user account having access to, at least, one station
+- An application registered from the user account (see http://dev.netatmo.com/dev/createapp) to obtain application credentials.
 
 In the netatmo philosophy, both the application itself and the user have to be registered thus have authentication credentials to be able to access any station. Registration is free for both.
 
-
-
-### 2 Setup your library ###
-
-
+### 2 Setup your library
 
 Install `pyatmo` as described in the `README.md`.
 
@@ -55,18 +42,13 @@ $ echo $?
 0
 ```
 
-
-
-### 3 Package guide ###
-
-
+### 3 Package guide
 
 Most of the time, the sequence of operations will be :
 
-  1. Authenticate your program against Netatmo web server
-  2. Get the device list accessible to the user
-  3. Request data on one of these devices or directly access last data sent by the station
-
+1. Authenticate your program against Netatmo web server
+2. Get the device list accessible to the user
+3. Request data on one of these devices or directly access last data sent by the station
 
 Example :
 
@@ -86,14 +68,15 @@ authorization = pyatmo.ClientAuth(
 )
 
 # 2 : Get devices list
-weatherData = pyatmo.WeatherStationData(authorization)
+weather_data = pyatmo.WeatherStationData(authorization)
+weather_data.update()
 
 # 3 : Access most fresh data directly
 print(
     "Current temperature (inside/outside): %s / %s °C"
     % (
-        weatherData.last_data()["indoor"]["Temperature"],
-        weatherData.last_data()["outdoor"]["Temperature"],
+        weather_data.last_data()["indoor"]["Temperature"],
+        weather_data.last_data()["outdoor"]["Temperature"],
     )
 )
 ```
@@ -109,22 +92,16 @@ modules**.
 
 Having two roles, the station has a 'station_name' property as well as a 'module_name' for its internal sensor.
 
->Exception : to reflect again the API structure, the last data uploaded by the station is indexed by module_name (wether it is a station module or an external module).
-
+> Exception : to reflect again the API structure, the last data uploaded by the station is indexed by module_name (wether it is a station module or an external module).
 
 Sensors (stations and modules) are managed in the API using ID's (network hardware adresses). The Netatmo web account management gives you the capability to associate names to station sensor and module (and to the station itself). This is by far more comfortable and the interface provides service to locate a station or a module by name or by Id depending of your taste. Module lookup by name includes the optional station name in case
 multiple stations would have similar module names (if you monitor multiple stations/locations, it would not be a surprise that each of them would have an 'outdoor' module). This is a benefit in the sense it give you the ability to write generic code (for example, collect all 'outdoor' temperatures for all your stations).
 
 The results are Python data structures, mostly dictionaries as they mirror easily the JSON returned data. All supplied classes provides simple properties to use as well as access to full data returned by the netatmo web services (rawData property for most classes).
 
+### 4 Package classes and functions
 
-
-### 4 Package classes and functions ###
-
-
-
-#### 4-1 Global variables ####
-
+#### 4-1 Global variables
 
 ```python
 _BASE_URL and _*_REQ : Various URL to access Netatmo web services. They are
@@ -132,11 +109,7 @@ documented in http://dev.netatmo.com/doc/ They should not be changed unless
 Netatmo API changes.
 ```
 
-
-
-#### 4-2 ClientAuth class ####
-
-
+#### 4-2 ClientAuth class
 
 Constructor
 
@@ -150,46 +123,38 @@ authorization = pyatmo.ClientAuth(
 )
 ```
 
-
 Requires : Application and User credentials to access Netatmo API.
-
 
 Return : an authorization object that will supply the access token required by other web services. This class will handle the renewal of the access token if expiration is reached.
 
-
 Properties, all properties are read-only unless specified :
 
-  * **accessToken** : Retrieve a valid access token (renewed if necessary)
-  * **refreshToken** : The token used to renew the access token (normally should not be used)
-  * **expiration** : The expiration time (epoch) of the current token
-  * **scope** : The scope of the required access token (what will it be used for) default to read_station to provide backward compatibility.
+- **accessToken** : Retrieve a valid access token (renewed if necessary)
+- **refreshToken** : The token used to renew the access token (normally should not be used)
+- **expiration** : The expiration time (epoch) of the current token
+- **scope** : The scope of the required access token (what will it be used for) default to read_station to provide backward compatibility.
 
 Possible values for scope are :
- - read_station: to retrieve weather station data (Getstationsdata, Getmeasure)
- - read_camera: to retrieve Welcome camera data (Gethomedata, Getcamerapicture)
- - access_camera: to access the camera, the videos and the live stream.
- - read_thermostat: to retrieve thermostat data (Getmeasure, Getthermostatsdata)
- - write_thermostat: to set up the thermostat (Syncschedule, Setthermpoint)
- - read_presence: to retrieve Presence data (Gethomedata, Getcamerapicture)
- - access_presence: to access the camera, the videos and the live stream.
+
+- read_station: to retrieve weather station data (Getstationsdata, Getmeasure)
+- read_camera: to retrieve Welcome camera data (Gethomedata, Getcamerapicture)
+- access_camera: to access the camera, the videos and the live stream.
+- read_thermostat: to retrieve thermostat data (Getmeasure, Getthermostatsdata)
+- write_thermostat: to set up the thermostat (Syncschedule, Setthermpoint)
+- read_presence: to retrieve Presence data (Gethomedata, Getcamerapicture)
+- access_presence: to access the camera, the videos and the live stream.
 
 Several value can be used at the same time, ie: 'read_station read_camera'
 
-
-
-#### 4-3 WeatherStationData class ####
-
-
+#### 4-3 WeatherStationData class
 
 Constructor
 
 ```python
-weatherData = pyatmo.WeatherStationData(authorization)
+weather_data = pyatmo.WeatherStationData(authorization)
 ```
 
-
 Requires : an authorization object (ClientAuth instance)
-
 
 Return : a WeatherStationData object. This object contains most administration properties of stations and modules accessible to the user and the last data pushed by the station to the Netatmo servers.
 
@@ -197,109 +162,114 @@ Raise a pyatmo.NoDevice exception if no weather station is available for the giv
 
 Properties, all properties are read-only unless specified:
 
-
-  * **rawData** : Full dictionary of the returned JSON DEVICELIST Netatmo API service
-  * **default_station** : Name of the first station returned by the web service (warning, this is mainly for the ease of use of peoples having only 1 station).
-  * **stations** : Dictionary of stations (indexed by ID) accessible to this user account
-  * **modules** : Dictionary of modules (indexed by ID) accessible to the user account (whatever station there are plugged in)
-
+- **rawData** : Full dictionary of the returned JSON DEVICELIST Netatmo API service
+- **default_station** : Name of the first station returned by the web service (warning, this is mainly for the ease of use of peoples having only 1 station).
+- **stations** : Dictionary of stations (indexed by ID) accessible to this user account
+- **modules** : Dictionary of modules (indexed by ID) accessible to the user account (whatever station there are plugged in)
 
 Methods :
 
+- **station_by_name** (station=None) : Find a station by it's station name
 
-  * **station_by_name** (station=None) : Find a station by it's station name
-    * Input : Station name to lookup (str)
-    * Output : station dictionary or None
+  - Input : Station name to lookup (str)
+  - Output : station dictionary or None
 
-  * **station_by_id** (sid) : Find a station by it's Netatmo ID (mac address)
-    * Input : Station ID
-    * Output : station dictionary or None
+- **station_by_id** (sid) : Find a station by it's Netatmo ID (mac address)
 
-  * **module_by_name** (module, station=None) : Find a module by it's module name
-    * Input : module name and optional station name
-    * Output : module dictionary or None
+  - Input : Station ID
+  - Output : station dictionary or None
 
-     The station name parameter, if provided, is used to check wether the module belongs to the appropriate station (in case multiple stations would have same module name).
+- **module_by_name** (module, station=None) : Find a module by it's module name
 
-  * **module_by_id** (mid, sid=None) : Find a module by it's ID and belonging station's ID
-    * Input : module ID and optional Station ID
-    * Output : module dictionary or None
+  - Input : module name and optional station name
+  - Output : module dictionary or None
 
-  * **modules_names_list** (station=None) : Get the list of modules names, including the station module name. Each of them should have a corresponding entry in last_data. It is an equivalent (at lower cost) for last_data.keys()
+  The station name parameter, if provided, is used to check wether the module belongs to the appropriate station (in case multiple stations would have same module name).
 
-  * **last_data** (station=None, exclude=0) : Get the last data uploaded by the station, exclude sensors with measurement older than given value (default return all)
-    * Input : station name OR id. If not provided default_station is used. Exclude is the delay in seconds from now to filter sensor readings.
-    * Output : Sensors data dictionary (Key is sensor name)
+- **module_by_id** (mid, sid=None) : Find a module by it's ID and belonging station's ID
 
-     AT the time of this document, Available measures types are :
-      * a full or subset of Temperature, Pressure, Noise, Co2, Humidity, Rain (mm of precipitation during the last 5 minutes, or since the previous data upload), When (measurement timestamp) for modules including station module
-      * battery_vp : likely to be total battery voltage for external sensors (running on batteries) in mV (undocumented)
-      * rf_status : likely to be the % of radio signal between the station and a module (undocumented)
+  - Input : module ID and optional Station ID
+  - Output : module dictionary or None
 
-     See Netatmo API documentation for units of regular measurements
+- **modules_names_list** (station=None) : Get the list of modules names, including the station module name. Each of them should have a corresponding entry in last_data. It is an equivalent (at lower cost) for last_data.keys()
 
-     If you named the internal sensor 'indoor' and the outdoor one 'outdoor' (simple is'n it ?) for your station in the user Web account station properties, you will access the data by :
+- **last_data** (station=None, exclude=0) : Get the last data uploaded by the station, exclude sensors with measurement older than given value (default return all)
+
+  - Input : station name OR id. If not provided default_station is used. Exclude is the delay in seconds from now to filter sensor readings.
+  - Output : Sensors data dictionary (Key is sensor name)
+
+  AT the time of this document, Available measures types are :
+
+  - a full or subset of Temperature, Pressure, Noise, Co2, Humidity, Rain (mm of precipitation during the last 5 minutes, or since the previous data upload), When (measurement timestamp) for modules including station module
+  - battery_vp : likely to be total battery voltage for external sensors (running on batteries) in mV (undocumented)
+  - rf_status : likely to be the % of radio signal between the station and a module (undocumented)
+
+  See Netatmo API documentation for units of regular measurements
+
+  If you named the internal sensor 'indoor' and the outdoor one 'outdoor' (simple is'n it ?) for your station in the user Web account station properties, you will access the data by :
 
 ```python
 # Last data access example
 
-theData = weatherData.last_data()
-print('Available modules : ', theData.keys())
-print('In-house CO2 level : ', theData['indoor']['Co2'])
-print('Outside temperature : ', theData['outdoor']['Temperature'])
-print('External module battery : ', "OK" if int(theData['outdoor']['battery_vp']) > 5000 \
+the_data = weather_data.last_data()
+print('Available modules : ', the_data.keys())
+print('In-house CO2 level : ', the_data['indoor']['Co2'])
+print('Outside temperature : ', the_data['outdoor']['Temperature'])
+print('External module battery : ', "OK" if int(the_data['outdoor']['battery_vp']) > 5000 \
                                          else "NEEDS TO BE REPLACED")
 ```
-  * **check_not_updated** (station=None, delay=3600) :
-    * Input : optional station name (else default_station is used)
-    * Output : list of modules name for which last data update is older than specified delay (default 1 hour). If the station itself is lost, the module_name of the station will be returned (the key item of last_data information).
 
-     For example (following the previous one)
+- **check_not_updated** (station=None, delay=3600) :
+
+  - Input : optional station name (else default_station is used)
+  - Output : list of modules name for which last data update is older than specified delay (default 1 hour). If the station itself is lost, the module_name of the station will be returned (the key item of last_data information).
+
+  For example (following the previous one)
 
 ```python
 # Ensure data sanity
 
-for m in weatherData.check_not_updated("<optional station name>"):
+for m in weather_data.check_not_updated("<optional station name>"):
     print("Warning, sensor %s information is obsolete" % m)
     if module_by_name(m) == None : # Sensor is not an external module
         print("The station is lost")
 ```
-  * **check_updated** (station=None, delay=3600) :
-    * Input : optional station name (else default_station is used)
-    * Output : list of modules name for which last data update is newer than specified delay (default 1 hour).
 
-     Complement of the previous service
+- **check_updated** (station=None, delay=3600) :
 
-  * **get_measure** (device_id, scale, mtype, module_id=None, date_begin=None, date_end=None, limit=None, optimize=False) :
-    * Input : All parameters specified in the Netatmo API service GETMEASURE (type being a python reserved word as been replaced by mtype).
-    * Output : A python dictionary reflecting the full service response. No transformation is applied.
-  * **min_max_th** (station=None, module=None, frame="last24") : Return min and max temperature and humidity for the given station/module in the given timeframe
-    * Input :
-      * An optional station Name or ID, default_station is used if not supplied,
-      * An optional module name or ID, default : station sensor data is used
-      * A time frame that can be :
-        * "last24" : For a shifting window of the last 24 hours
-        * "day" : For all available data in the current day
-    * Output :
-      * A 4 values tuple (Temp mini, Temp maxi, Humid mini, Humid maxi)
+  - Input : optional station name (else default_station is used)
+  - Output : list of modules name for which last data update is newer than specified delay (default 1 hour).
 
-     >Note : I have been obliged to determine the min and max manually, the built-in service in the API doesn't always provide the actual min and max. The double parameter (scale) and aggregation request (min, max) is not satisfying
-at all if you slip over two days as required in a shifting 24 hours window.
+  Complement of the previous service
 
+- **get_measure** (device_id, scale, mtype, module_id=None, date_begin=None, date_end=None, limit=None, optimize=False) :
+  - Input : All parameters specified in the Netatmo API service GETMEASURE (type being a python reserved word as been replaced by mtype).
+  - Output : A python dictionary reflecting the full service response. No transformation is applied.
+- **min_max_th** (station=None, module=None, frame="last24") : Return min and max temperature and humidity for the given station/module in the given timeframe
+  _ Input :
+  _ An optional station Name or ID, default\*station is used if not supplied,
 
-#### 4-4 CameraData class ####
+  - An optional module name or ID, default : station sensor data is used
+    _ A time frame that can be :
+    _ "last24" : For a shifting window of the last 24 hours
+    _ "day" : For all available data in the current day
+    _ Output :
+    \_ A 4 values tuple (Temp mini, Temp maxi, Humid mini, Humid maxi)
 
+         >Note : I have been obliged to determine the min and max manually, the built-in service in the API doesn't always provide the actual min and max. The double parameter (scale) and aggregation request (min, max) is not satisfying
 
+  at all if you slip over two days as required in a shifting 24 hours window.
+
+#### 4-4 CameraData class
 
 Constructor
 
 ```python
-cameraData = pyatmo.CameraData( authorization )
+camera_data = pyatmo.CameraData(authorization)
+camera_data.update()
 ```
 
-
 Requires : an authorization object (ClientAuth instance)
-
 
 Return : a CameraData object. This object contains most administration properties of Netatmo cameras accessible to the user and the last data pushed by the cameras to the Netatmo servers.
 
@@ -307,135 +277,136 @@ Raise a pyatmo.NoDevice exception if no camera is available for the given accoun
 
 Properties, all properties are read-only unless specified:
 
-
-  * **rawData** : Full dictionary of the returned JSON DEVICELIST Netatmo API service
-  * **default_home** : Name of the first home returned by the web service (warning, this is mainly for the ease of use of peoples having cameras in only 1 house).
-  * **default_camera** : Data of the first camera in the default home returned by the web service (warning, this is mainly for the ease of use of peoples having only 1 camera).
-  * **homes** : Dictionary of homes (indexed by ID) accessible to this user account
-  * **cameras** : Dictionary of cameras (indexed by home name and cameraID) accessible to this user
-  * **persons** : Dictionary of persons (indexed by ID) accessible to the user account
-  * **events** : Dictionary of events (indexed by cameraID and timestamp) seen by cameras
-  * **outdoor_events** : Dictionary of Outdoor events (indexed by cameraID and timestamp) seen by cameras
-
+- **rawData** : Full dictionary of the returned JSON DEVICELIST Netatmo API service
+- **default_home** : Name of the first home returned by the web service (warning, this is mainly for the ease of use of peoples having cameras in only 1 house).
+- **default_camera** : Data of the first camera in the default home returned by the web service (warning, this is mainly for the ease of use of peoples having only 1 camera).
+- **homes** : Dictionary of homes (indexed by ID) accessible to this user account
+- **cameras** : Dictionary of cameras (indexed by home name and cameraID) accessible to this user
+- **persons** : Dictionary of persons (indexed by ID) accessible to the user account
+- **events** : Dictionary of events (indexed by cameraID and timestamp) seen by cameras
+- **outdoor_events** : Dictionary of Outdoor events (indexed by cameraID and timestamp) seen by cameras
 
 Methods :
 
-  * **home_by_id** (hid) : Find a home by its Netatmo ID
-    * Input : Home ID
-    * Output : home dictionary or None
+- **home_by_id** (hid) : Find a home by its Netatmo ID
 
-  * **home_by_name** (home=None) : Find a home by it's home name
-    * Input : home name to lookup (str)
-    * Output : home dictionary or None
+  - Input : Home ID
+  - Output : home dictionary or None
 
-  * **camera_by_id** (hid) : Find a camera by its Netatmo ID
-    * Input : camera ID
-    * Output : camera dictionary or None
+- **home_by_name** (home=None) : Find a home by it's home name
 
-  * **camera_by_name** (camera=None, home=None) : Find a camera by it's camera name
-    * Input : camera name and home name to lookup (str)
-    * Output : camera dictionary or None
+  - Input : home name to lookup (str)
+  - Output : home dictionary or None
 
-  * **camera_type** (camera=None, home=None, cid=None) : Return the type of a given camera.
-    * Input : camera name and home name or cameraID to lookup (str)
-    * Output : Return the type of a given camera
+- **camera_by_id** (hid) : Find a camera by its Netatmo ID
 
-  * **camera_urls_by_name** (camera=None, home=None, cid=None) : return Urls to access camera live feed
-    * Input : camera name and home name or cameraID to lookup (str)
-    * Output : tuple with the vpn_url (for remote access) and local url to access the camera live feed
+  - Input : camera ID
+  - Output : camera dictionary or None
 
-  * **persons_at_home_by_name** (home=None) : return the list of known persons who are at home
-    * Input : home name to lookup (str)
-    * Output : list of persons seen
+- **camera_by_name** (camera=None, home=None) : Find a camera by it's camera name
 
-  * **get_camera_picture** (image_id, key): Download a specific image (of an event or user face) from the camera
-    * Input : image_id and key of an events or person face
-    * Output: Tuple with image data (to be stored in a file) and image type (jpg, png...)
+  - Input : camera name and home name to lookup (str)
+  - Output : camera dictionary or None
 
-  * **get_profile_image** (name) : Retrieve the face of a given person
-    * Input : person name (str)
-    * Output: **get_camera_picture** data
+- **camera_type** (camera=None, home=None, cid=None) : Return the type of a given camera.
 
-  * **update_event** (event=None, home=None, cameratype=None): Update the list of events
-    * Input: Id of the latest event, home name and cameratype to update event list
+  - Input : camera name and home name or cameraID to lookup (str)
+  - Output : Return the type of a given camera
 
-  * **person_seen_by_camera** (name, home=None, camera=None): Return true is a specific person has been seen by the camera in the last event
+- **camera_urls_by_name** (camera=None, home=None, cid=None) : return Urls to access camera live feed
 
-  * **someone_known_seen** (home=None, camera=None) : Return true is a known person has been in the last event
+  - Input : camera name and home name or cameraID to lookup (str)
+  - Output : tuple with the vpn_url (for remote access) and local url to access the camera live feed
 
-  * **someone_unknown_seen** (home=None, camera=None) : Return true is an unknown person has been seen in the last event
+- **persons_at_home_by_name** (home=None) : return the list of known persons who are at home
 
-  * **motion_detected** (home=None, camera=None) : Return true is a movement has been detected in the last event
+  - Input : home name to lookup (str)
+  - Output : list of persons seen
 
-  * **outdoormotion_detected** (home=None, camera=None) : Return true is a outdoor movement has been detected in the last event
+- **get_camera_picture** (image_id, key): Download a specific image (of an event or user face) from the camera
 
-  * **humanDetected** (home=None, camera=None) : Return True if a human has been detected in the last outdoor events
+  - Input : image_id and key of an events or person face
+  - Output: Tuple with image data (to be stored in a file) and image type (jpg, png...)
 
-  * **animalDetected** (home=None, camera=None) : Return True if an animal has been detected in the last outdoor events
+- **get_profile_image** (name) : Retrieve the face of a given person
 
-  * **carDetected** (home=None, camera=None) : Return True if a car has been detected in the last outdoor events
+  - Input : person name (str)
+  - Output: **get_camera_picture** data
 
+- **update_event** (event=None, home=None, cameratype=None): Update the list of events
 
+  - Input: Id of the latest event, home name and cameratype to update event list
 
-  #### 4-5 ThermostatData class ####
+- **person_seen_by_camera** (name, home=None, camera=None): Return true is a specific person has been seen by the camera in the last event
 
+- **someone_known_seen** (home=None, camera=None) : Return true is a known person has been in the last event
 
+- **someone_unknown_seen** (home=None, camera=None) : Return true is an unknown person has been seen in the last event
 
-  Constructor
+- **motion_detected** (home=None, camera=None) : Return true is a movement has been detected in the last event
 
-  ```python
-  thermostatData = pyatmo.ThermostatData(authorization)
-  ```
+- **outdoormotion_detected** (home=None, camera=None) : Return true is a outdoor movement has been detected in the last event
 
+- **humanDetected** (home=None, camera=None) : Return True if a human has been detected in the last outdoor events
 
-  Requires : an authorization object (ClientAuth instance)
+- **animalDetected** (home=None, camera=None) : Return True if an animal has been detected in the last outdoor events
 
+- **carDetected** (home=None, camera=None) : Return True if a car has been detected in the last outdoor events
 
-  Return : a ThermostatData object. This object contains most administration properties of Netatmo thermostats accessible to the user and the last data pushed by the thermostats to the Netatmo servers.
+#### 4-5 ThermostatData class
 
-  Raise a pyatmo.NoDevice exception if no thermostat is available for the given account.
+Constructor
 
-  Properties, all properties are read-only unless specified:
+```python
+thermostat_data = pyatmo.ThermostatData(authorization)
+thermostat_data.update()
+```
 
+Requires : an authorization object (ClientAuth instance)
 
-  * **rawData** : Full dictionary of the returned JSON Netatmo API service
-  * **devList** : Full dictionary of the returned JSON DEVICELIST Netatmo API service
-  * **default_device** : Name of the first device returned by the web service (warning, this is mainly for the ease of use of peoples having multiple thermostats in only 1 house).
-  * **default_module** : Data of the first module in the default device returned by the web service (warning, this is mainly for the ease of use of peoples having only 1 thermostat).
-  * **devices** : Dictionary of devices (indexed by ID) accessible to this user account
-  * **modules** : Dictionary of modules (indexed by device name and moduleID) accessible to this user
-  * **therm_program_list** : Dictionary of therm programs (indexed by ID) accessible to the user account
-  * **zones** : Dictionary of zones (indexed by ID)
-  * **timetable** : Dictionary of timetable (indexed by m_offset)
+Return : a ThermostatData object. This object contains most administration properties of Netatmo thermostats accessible to the user and the last data pushed by the thermostats to the Netatmo servers.
 
+Raise a pyatmo.NoDevice exception if no thermostat is available for the given account.
 
-  Methods :
+Properties, all properties are read-only unless specified:
 
-  * **deviceById** (hid) : Find a device by its Netatmo ID
-      * Input : Device ID
-      * Output : device dictionary or None
+- **rawData** : Full dictionary of the returned JSON Netatmo API service
+- **devList** : Full dictionary of the returned JSON DEVICELIST Netatmo API service
+- **default_device** : Name of the first device returned by the web service (warning, this is mainly for the ease of use of peoples having multiple thermostats in only 1 house).
+- **default_module** : Data of the first module in the default device returned by the web service (warning, this is mainly for the ease of use of peoples having only 1 thermostat).
+- **devices** : Dictionary of devices (indexed by ID) accessible to this user account
+- **modules** : Dictionary of modules (indexed by device name and moduleID) accessible to this user
+- **therm_program_list** : Dictionary of therm programs (indexed by ID) accessible to the user account
+- **zones** : Dictionary of zones (indexed by ID)
+- **timetable** : Dictionary of timetable (indexed by m_offset)
 
-  * **deviceByName** (device=None) : Find a device by it's device name
-      * Input : device name to lookup (str)
-      * Output : device dictionary or None
+Methods :
 
-  * **module_by_id** (hid) : Find a module by its Netatmo ID
-      * Input : module ID
-      * Output : module dictionary or None
+- **deviceById** (hid) : Find a device by its Netatmo ID
 
-  * **module_by_name** (module=None, device=None) : Find a module by it's module name
-      * Input : module name and device name to lookup (str)
-      * Output : module dictionary or None
+  - Input : Device ID
+  - Output : device dictionary or None
 
-  * **setthermpoint** (mode, temp, endTimeOffsetmode, temp, endTimeOffset) : set thermpoint
-      * Input : device_id and module_id and setpoint_mode
+- **deviceByName** (device=None) : Find a device by it's device name
 
+  - Input : device name to lookup (str)
+  - Output : device dictionary or None
 
+- **module_by_id** (hid) : Find a module by its Netatmo ID
 
+  - Input : module ID
+  - Output : module dictionary or None
 
-#### 4-6 Utilities functions ####
+- **module_by_name** (module=None, device=None) : Find a module by it's module name
 
+  - Input : module name and device name to lookup (str)
+  - Output : module dictionary or None
 
-  * **to_time_string** (timestamp) : Convert a Netatmo time stamp to a readable date/time format.
-  * **to_epoch**( dateString) : Convert a date string (form YYYY-MM-DD_HH:MM:SS) to timestamp
-  * **today_stamps**() : Return a couple of epoch time (start, end) for the current day
+- **setthermpoint** (mode, temp, endTimeOffsetmode, temp, endTimeOffset) : set thermpoint
+  - Input : device_id and module_id and setpoint_mode
+
+#### 4-6 Utilities functions
+
+- **to_time_string** (timestamp) : Convert a Netatmo time stamp to a readable date/time format.
+- **to_epoch**( dateString) : Convert a date string (form YYYY-MM-DD_HH:MM:SS) to timestamp
+- **today_stamps**() : Return a couple of epoch time (start, end) for the current day


### PR DESCRIPTION
**Breaking change!**
This breaks the interface and requires separate calls to update/fetch data from the Netatmo API.

In order to not cause I/O during initialization the data retrieval and processing is moved into separate functions. 