### PR TITLE
Fix parameter order of set person home/away methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
--
+- [BREAKING] Fix parameter order of set person home/away methods
 
 ### Deprecated
 

--- a/src/pyatmo/camera.py
+++ b/src/pyatmo/camera.py
@@ -516,15 +516,17 @@ class CameraData(AbstractCameraData):
         LOG.debug("%s", resp)
         return True
 
-    def set_persons_home(self, person_ids: list[str], home_id: str):
+    def set_persons_home(self, home_id: str, person_ids: list[str] = None):
         """Mark persons as home."""
-        post_params = {"home_id": home_id, "person_ids[]": person_ids}
+        post_params: dict[str, str | list] = {"home_id": home_id}
+        if person_ids:
+            post_params["person_ids[]"] = person_ids
         return self.auth.post_request(
             url=_SETPERSONSHOME_REQ,
             params=post_params,
         ).json()
 
-    def set_persons_away(self, person_id: str, home_id: str):
+    def set_persons_away(self, home_id: str, person_id: str = None):
         """Mark a person as away or set the whole home to being empty."""
         post_params = {"home_id": home_id, "person_id": person_id}
         return self.auth.post_request(
@@ -711,17 +713,25 @@ class AsyncCameraData(AbstractCameraData):
                     temp_local_url,
                 )
 
-    async def async_set_persons_home(self, person_ids: list[str], home_id: str):
+    async def async_set_persons_home(
+        self,
+        home_id: str,
+        person_ids: list[str] = None,
+    ):
         """Mark persons as home."""
-        post_params = {"home_id": home_id, "person_ids[]": person_ids}
+        post_params: dict[str, str | list] = {"home_id": home_id}
+        if person_ids:
+            post_params["person_ids[]"] = person_ids
         return await self.auth.async_post_request(
             url=_SETPERSONSHOME_REQ,
             params=post_params,
         )
 
-    async def async_set_persons_away(self, person_id: str, home_id: str):
+    async def async_set_persons_away(self, home_id: str, person_id: str = None):
         """Mark a person as away or set the whole home to being empty."""
-        post_params = {"home_id": home_id, "person_id": person_id}
+        post_params = {"home_id": home_id}
+        if person_id:
+            post_params["person_id"] = person_id
         return await self.auth.async_post_request(
             url=_SETPERSONSAWAY_REQ,
             params=post_params,

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -468,3 +468,123 @@ async def test_async_camera_data_get_profile_image(async_camera_home_data):
             None,
             None,
         )
+
+
+@pytest.mark.parametrize(
+    "home_id, person_id, json_fixture, expected",
+    [
+        (
+            "91763b24c43d3e344f424e8b",
+            "91827374-7e04-5298-83ad-a0cb8372dff1",
+            "status_ok.json",
+            "ok",
+        ),
+        (
+            "91763b24c43d3e344f424e8b",
+            "91827376-7e04-5298-83af-a0cb8372dff3",
+            "status_ok.json",
+            "ok",
+        ),
+        (
+            "91763b24c43d3e344f424e8b",
+            None,
+            "status_ok.json",
+            "ok",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_async_camera_data_set_persons_away(
+    async_camera_home_data,
+    home_id,
+    person_id,
+    json_fixture,
+    expected,
+):
+    with open("fixtures/%s" % json_fixture) as json_file:
+        json_fixture = json.load(json_file)
+    with patch(
+        "pyatmo.auth.AbstractAsyncAuth.async_post_request",
+        AsyncMock(return_value=json_fixture),
+    ) as mock_req:
+        result = await async_camera_home_data.async_set_persons_away(home_id, person_id)
+        assert result["status"] == expected
+
+    if person_id is not None:
+        mock_req.assert_called_once_with(
+            params={
+                "home_id": home_id,
+                "person_id": person_id,
+            },
+            url="https://api.netatmo.com/api/setpersonsaway",
+        )
+    else:
+        mock_req.assert_called_once_with(
+            params={
+                "home_id": home_id,
+            },
+            url="https://api.netatmo.com/api/setpersonsaway",
+        )
+
+
+@pytest.mark.parametrize(
+    "home_id, person_ids, json_fixture, expected",
+    [
+        (
+            "91763b24c43d3e344f424e8b",
+            [
+                "91827374-7e04-5298-83ad-a0cb8372dff1",
+                "91827376-7e04-5298-83af-a0cb8372dff3",
+            ],
+            "status_ok.json",
+            "ok",
+        ),
+        (
+            "91763b24c43d3e344f424e8b",
+            "91827376-7e04-5298-83af-a0cb8372dff3",
+            "status_ok.json",
+            "ok",
+        ),
+        (
+            "91763b24c43d3e344f424e8b",
+            None,
+            "status_ok.json",
+            "ok",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_async_camera_data_set_persons_home(
+    async_camera_home_data,
+    home_id,
+    person_ids,
+    json_fixture,
+    expected,
+):
+    with open("fixtures/%s" % json_fixture) as json_file:
+        json_fixture = json.load(json_file)
+    with patch(
+        "pyatmo.auth.AbstractAsyncAuth.async_post_request",
+        AsyncMock(return_value=json_fixture),
+    ) as mock_req:
+        result = await async_camera_home_data.async_set_persons_home(
+            home_id,
+            person_ids,
+        )
+        assert result["status"] == expected
+
+    if isinstance(person_ids, list) or person_ids:
+        mock_req.assert_called_once_with(
+            params={
+                "home_id": home_id,
+                "person_ids[]": person_ids,
+            },
+            url="https://api.netatmo.com/api/setpersonshome",
+        )
+    else:
+        mock_req.assert_called_once_with(
+            params={
+                "home_id": home_id,
+            },
+            url="https://api.netatmo.com/api/setpersonshome",
+        )

--- a/tests/test_pyatmo_camera.py
+++ b/tests/test_pyatmo_camera.py
@@ -194,6 +194,12 @@ def test_camera_data_get_person_id(camera_home_data, name, expected):
             "status_ok.json",
             "ok",
         ),
+        (
+            "91763b24c43d3e344f424e8b",
+            None,
+            "status_ok.json",
+            "ok",
+        ),
     ],
 )
 def test_camera_data_set_persons_away(
@@ -206,12 +212,19 @@ def test_camera_data_set_persons_away(
 ):
     with open("fixtures/%s" % json_fixture) as json_file:
         json_fixture = json.load(json_file)
-    requests_mock.post(
+    mock_req = requests_mock.post(
         pyatmo.camera._SETPERSONSAWAY_REQ,
         json=json_fixture,
         headers={"content-type": "application/json"},
     )
-    assert camera_home_data.set_persons_away(person_id, home_id)["status"] == expected
+    assert camera_home_data.set_persons_away(home_id, person_id)["status"] == expected
+    if person_id is not None:
+        assert (
+            mock_req.request_history[0].text
+            == f"home_id={home_id}&person_id={person_id}"
+        )
+    else:
+        assert mock_req.request_history[0].text == f"home_id={home_id}"
 
 
 @pytest.mark.parametrize(
@@ -232,6 +245,12 @@ def test_camera_data_set_persons_away(
             "status_ok.json",
             "ok",
         ),
+        (
+            "91763b24c43d3e344f424e8b",
+            None,
+            "status_ok.json",
+            "ok",
+        ),
     ],
 )
 def test_camera_data_set_persons_home(
@@ -244,12 +263,25 @@ def test_camera_data_set_persons_home(
 ):
     with open("fixtures/%s" % json_fixture) as json_file:
         json_fixture = json.load(json_file)
-    requests_mock.post(
+    mock_req = requests_mock.post(
         pyatmo.camera._SETPERSONSHOME_REQ,
         json=json_fixture,
         headers={"content-type": "application/json"},
     )
-    assert camera_home_data.set_persons_home(person_ids, home_id)["status"] == expected
+    assert camera_home_data.set_persons_home(home_id, person_ids)["status"] == expected
+
+    if isinstance(person_ids, list):
+        assert (
+            mock_req.request_history[0].text
+            == f"home_id={home_id}&person_ids%5B%5D={'&person_ids%5B%5D='.join(person_ids)}"
+        )
+    elif person_ids:
+        assert (
+            mock_req.request_history[0].text
+            == f"home_id={home_id}&person_ids%5B%5D={person_ids}"
+        )
+    else:
+        assert mock_req.request_history[0].text == f"home_id={home_id}"
 
 
 @freeze_time("2019-06-16")


### PR DESCRIPTION
The incorrect order or parameters prevented passing in only the home id to set the whole home home/away.

Original HA issue: https://github.com/home-assistant/core/issues/51782