### PR TITLE
feat: add support for third-party Netatmo APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Fetch favorite weather sensors
+- Add support for third-party Netatmo devices (see `base_url` and `user_prefix` parameters)
 
 ### Changed
 

--- a/src/pyatmo/auth.py
+++ b/src/pyatmo/auth.py
@@ -106,7 +106,9 @@ class NetatmoOAuth2:
 
     def refresh_tokens(self) -> dict[str, str | int]:
         """Refresh and return new tokens."""
-        token = self._oauth.refresh_token(self.base_url + AUTH_REQ_ENDPOINT, **self.extra)
+        token = self._oauth.refresh_token(
+            self.base_url + AUTH_REQ_ENDPOINT, **self.extra
+        )
 
         if self.token_updater is not None:
             self.token_updater(token)
@@ -119,7 +121,9 @@ class NetatmoOAuth2:
         params: dict | None = None,
         timeout: int = 5,
     ) -> requests.Response:
-        return self.post_request(url=self.base_url + endpoint, params=params, timeout=timeout)
+        return self.post_request(
+            url=self.base_url + endpoint, params=params, timeout=timeout
+        )
 
     def post_request(
         self,
@@ -223,7 +227,7 @@ class NetatmoOAuth2:
             code=code,
             client_secret=self.client_secret,
             include_client_id=True,
-            user_prefix=self.user_prefix
+            user_prefix=self.user_prefix,
         )
 
     def addwebhook(self, webhook_url: str) -> None:
@@ -271,8 +275,13 @@ class ClientAuth(NetatmoOAuth2):
         user_prefix: str = None,
         base_url: str = _DEFAULT_BASE_URL,
     ):
-        super().__init__(client_id=client_id, client_secret=client_secret, scope=scope, user_prefix=user_prefix,
-                         base_url=base_url)
+        super().__init__(
+            client_id=client_id,
+            client_secret=client_secret,
+            scope=scope,
+            user_prefix=user_prefix,
+            base_url=base_url,
+        )
 
         self._oauth = OAuth2Session(
             client=LegacyApplicationClient(client_id=self.client_id),
@@ -284,7 +293,7 @@ class ClientAuth(NetatmoOAuth2):
             client_id=self.client_id,
             client_secret=self.client_secret,
             scope=self.scope,
-            user_prefix=self.user_prefix
+            user_prefix=self.user_prefix,
         )
 
 
@@ -340,7 +349,9 @@ class AbstractAsyncAuth(ABC):
         params: dict | None = None,
         timeout: int = 5,
     ) -> ClientResponse:
-        return await self.async_post_request(url=self.base_url + endpoint, params=params, timeout=timeout)
+        return await self.async_post_request(
+            url=self.base_url + endpoint, params=params, timeout=timeout
+        )
 
     async def async_post_request(
         self,

--- a/src/pyatmo/auth.py
+++ b/src/pyatmo/auth.py
@@ -107,7 +107,8 @@ class NetatmoOAuth2:
     def refresh_tokens(self) -> dict[str, str | int]:
         """Refresh and return new tokens."""
         token = self._oauth.refresh_token(
-            self.base_url + AUTH_REQ_ENDPOINT, **self.extra
+            self.base_url + AUTH_REQ_ENDPOINT,
+            **self.extra,
         )
 
         if self.token_updater is not None:
@@ -122,7 +123,9 @@ class NetatmoOAuth2:
         timeout: int = 5,
     ) -> requests.Response:
         return self.post_request(
-            url=self.base_url + endpoint, params=params, timeout=timeout
+            url=self.base_url + endpoint,
+            params=params,
+            timeout=timeout,
         )
 
     def post_request(
@@ -350,7 +353,9 @@ class AbstractAsyncAuth(ABC):
         timeout: int = 5,
     ) -> ClientResponse:
         return await self.async_post_request(
-            url=self.base_url + endpoint, params=params, timeout=timeout
+            url=self.base_url + endpoint,
+            params=params,
+            timeout=timeout,
         )
 
     async def async_post_request(

--- a/src/pyatmo/auth.py
+++ b/src/pyatmo/auth.py
@@ -13,17 +13,15 @@ from oauthlib.oauth2 import LegacyApplicationClient, TokenExpiredError
 from requests_oauthlib import OAuth2Session
 
 from pyatmo.exceptions import ApiError
-from pyatmo.helpers import _BASE_URL, ERRORS
+from pyatmo.helpers import _DEFAULT_BASE_URL, ERRORS
 
 LOG = logging.getLogger(__name__)
 
 # Common definitions
 AUTH_REQ_ENDPOINT = "oauth2/token"
-AUTH_REQ = _BASE_URL + AUTH_REQ_ENDPOINT
 AUTH_URL_ENDPOINT = "oauth2/authorize"
-AUTH_URL = _BASE_URL + AUTH_URL_ENDPOINT
-WEBHOOK_URL_ADD = _BASE_URL + "api/addwebhook"
-WEBHOOK_URL_DROP = _BASE_URL + "api/dropwebhook"
+WEBHOOK_URL_ADD_ENDPOINT = "api/addwebhook"
+WEBHOOK_URL_DROP_ENDPOINT = "api/dropwebhook"
 
 AUTHORIZATION_HEADER = "Authorization"
 
@@ -57,6 +55,8 @@ class NetatmoOAuth2:
         token: dict[str, str] | None = None,
         token_updater: Callable[[str], None] | None = None,
         scope: str | None = "read_station",
+        user_prefix: str | None = None,
+        base_url: str = _DEFAULT_BASE_URL,
     ) -> None:
         """Initialize self.
 
@@ -78,11 +78,15 @@ class NetatmoOAuth2:
                 read_homecoach: to retrieve Home Coache data (Gethomecoachsdata)
                 read_smokedetector: to retrieve the smoke detector status (Gethomedata)
                 Several values can be used at the same time, ie: 'read_station read_camera'
+            user_prefix {Optional[str]} -- API prefix for the Netatmo customer
+            base_url {str} -- Base URL of the Netatmo API (default: {_DEFAULT_BASE_URL})
         """
         self.client_id = client_id
         self.client_secret = client_secret
         self.redirect_uri = redirect_uri
         self.token_updater = token_updater
+        self.user_prefix = user_prefix
+        self.base_url = base_url
 
         if token:
             self.scope = " ".join(token["scope"])
@@ -102,12 +106,20 @@ class NetatmoOAuth2:
 
     def refresh_tokens(self) -> dict[str, str | int]:
         """Refresh and return new tokens."""
-        token = self._oauth.refresh_token(AUTH_REQ, **self.extra)
+        token = self._oauth.refresh_token(self.base_url + AUTH_REQ_ENDPOINT, **self.extra)
 
         if self.token_updater is not None:
             self.token_updater(token)
 
         return token
+
+    def post_api_request(
+        self,
+        endpoint: str,
+        params: dict | None = None,
+        timeout: int = 5,
+    ) -> requests.Response:
+        return self.post_request(url=self.base_url + endpoint, params=params, timeout=timeout)
 
     def post_request(
         self,
@@ -191,7 +203,7 @@ class NetatmoOAuth2:
         return requests.Response()
 
     def get_authorization_url(self, state: str | None = None) -> tuple:
-        return self._oauth.authorization_url(AUTH_URL, state)
+        return self._oauth.authorization_url(self.base_url + AUTH_URL_ENDPOINT, state)
 
     def request_token(
         self,
@@ -206,21 +218,22 @@ class NetatmoOAuth2:
         :return: A token dict
         """
         return self._oauth.fetch_token(
-            AUTH_REQ,
+            self.base_url + AUTH_REQ_ENDPOINT,
             authorization_response=authorization_response,
             code=code,
             client_secret=self.client_secret,
             include_client_id=True,
+            user_prefix=self.user_prefix
         )
 
     def addwebhook(self, webhook_url: str) -> None:
         post_params = {"url": webhook_url}
-        resp = self.post_request(WEBHOOK_URL_ADD, post_params)
+        resp = self.post_api_request(WEBHOOK_URL_ADD_ENDPOINT, post_params)
         LOG.debug("addwebhook: %s", resp)
 
     def dropwebhook(self) -> None:
         post_params = {"app_types": "app_security"}
-        resp = self.post_request(WEBHOOK_URL_DROP, post_params)
+        resp = self.post_api_request(WEBHOOK_URL_DROP_ENDPOINT, post_params)
         LOG.debug("dropwebhook: %s", resp)
 
 
@@ -244,6 +257,8 @@ class ClientAuth(NetatmoOAuth2):
             read_homecoach: to retrieve Home Coache data (Gethomecoachsdata)
             read_smokedetector: to retrieve the smoke detector status (Gethomedata)
             Several value can be used at the same time, ie: 'read_station read_camera'
+        user_prefix (Optional[str]) -- API prefix for the Netatmo customer
+        base_url (str) -- Base URL of the Netatmo API (default: {_DEFAULT_BASE_URL})
     """
 
     def __init__(
@@ -253,28 +268,33 @@ class ClientAuth(NetatmoOAuth2):
         username: str,
         password: str,
         scope="read_station",
+        user_prefix: str = None,
+        base_url: str = _DEFAULT_BASE_URL,
     ):
-        super().__init__(client_id=client_id, client_secret=client_secret, scope=scope)
+        super().__init__(client_id=client_id, client_secret=client_secret, scope=scope, user_prefix=user_prefix,
+                         base_url=base_url)
 
         self._oauth = OAuth2Session(
             client=LegacyApplicationClient(client_id=self.client_id),
         )
         self._oauth.fetch_token(
-            token_url=AUTH_REQ,
+            token_url=self.base_url + AUTH_REQ_ENDPOINT,
             username=username,
             password=password,
             client_id=self.client_id,
             client_secret=self.client_secret,
             scope=self.scope,
+            user_prefix=self.user_prefix
         )
 
 
 class AbstractAsyncAuth(ABC):
     """Abstract class to make authenticated requests."""
 
-    def __init__(self, websession: ClientSession) -> None:
+    def __init__(self, websession: ClientSession, base_url: str) -> None:
         """Initialize the auth."""
         self.websession = websession
+        self.base_url = base_url
 
     @abstractmethod
     async def async_get_access_token(self) -> str:
@@ -282,7 +302,7 @@ class AbstractAsyncAuth(ABC):
 
     async def async_get_image(
         self,
-        url: str,
+        endpoint: str,
         params: dict | None = None,
         timeout: int = 5,
     ) -> bytes:
@@ -295,6 +315,7 @@ class AbstractAsyncAuth(ABC):
 
         req_args = {"data": params if params is not None else {}}
 
+        url = self.base_url + endpoint
         async with self.websession.get(
             url,
             **req_args,
@@ -312,6 +333,14 @@ class AbstractAsyncAuth(ABC):
             f"invalid content-type in response"
             f"when accessing '{url}'",
         )
+
+    async def async_post_api_request(
+        self,
+        endpoint: str,
+        params: dict | None = None,
+        timeout: int = 5,
+    ) -> ClientResponse:
+        return await self.async_post_request(url=self.base_url + endpoint, params=params, timeout=timeout)
 
     async def async_post_request(
         self,
@@ -374,13 +403,16 @@ class AbstractAsyncAuth(ABC):
 
     async def async_addwebhook(self, webhook_url: str) -> None:
         """Register webhook."""
-        resp = await self.async_post_request(WEBHOOK_URL_ADD, {"url": webhook_url})
+        resp = await self.async_post_api_request(
+            WEBHOOK_URL_ADD_ENDPOINT,
+            {"url": webhook_url},
+        )
         LOG.debug("addwebhook: %s", resp)
 
     async def async_dropwebhook(self) -> None:
         """Unregister webhook."""
-        resp = await self.async_post_request(
-            WEBHOOK_URL_DROP,
+        resp = await self.async_post_api_request(
+            WEBHOOK_URL_DROP_ENDPOINT,
             {"app_types": "app_security"},
         )
         LOG.debug("dropwebhook: %s", resp)

--- a/src/pyatmo/auth.py
+++ b/src/pyatmo/auth.py
@@ -92,7 +92,7 @@ class NetatmoOAuth2:
             self.scope = " ".join(token["scope"])
 
         else:
-            self.scope = " ".join(ALL_SCOPES) if not scope else scope
+            self.scope = scope or " ".join(ALL_SCOPES)
 
         self.extra = {"client_id": self.client_id, "client_secret": self.client_secret}
 

--- a/src/pyatmo/camera.py
+++ b/src/pyatmo/camera.py
@@ -456,7 +456,9 @@ class CameraData(AbstractCameraData):
 
     def update(self, events: int = 30) -> None:
         """Fetch and process data from API."""
-        resp = self.auth.post_api_request(endpoint=_GETHOMEDATA_ENDPOINT, params={"size": events})
+        resp = self.auth.post_api_request(
+            endpoint=_GETHOMEDATA_ENDPOINT, params={"size": events}
+        )
 
         self.raw_data = extract_raw_data(resp.json(), "homes")
         self.process()
@@ -528,7 +530,9 @@ class CameraData(AbstractCameraData):
         }
 
         try:
-            resp = self.auth.post_api_request(endpoint=_SETSTATE_ENDPOINT, params=post_params).json()
+            resp = self.auth.post_api_request(
+                endpoint=_SETSTATE_ENDPOINT, params=post_params
+            ).json()
         except ApiError as err_msg:
             LOG.error("%s", err_msg)
             return False

--- a/src/pyatmo/camera.py
+++ b/src/pyatmo/camera.py
@@ -102,19 +102,25 @@ class AbstractCameraData(ABC):
 
     def get_camera(self, camera_id: str) -> dict[str, str]:
         """Get camera data."""
-        for home_id in self.cameras:
-            if camera_id in self.cameras[home_id]:
-                return self.cameras[home_id][camera_id]
-
-        return {}
+        return next(
+            (
+                self.cameras[home_id][camera_id]
+                for home_id in self.cameras
+                if camera_id in self.cameras[home_id]
+            ),
+            {},
+        )
 
     def get_camera_home_id(self, camera_id: str) -> str | None:
         """Get camera data."""
-        for home_id in self.cameras:
-            if camera_id in self.cameras[home_id]:
-                return home_id
-
-        return None
+        return next(
+            (
+                home_id
+                for home_id in self.cameras
+                if camera_id in self.cameras[home_id]
+            ),
+            None,
+        )
 
     def get_module(self, module_id: str) -> dict | None:
         """Get module data."""
@@ -122,11 +128,14 @@ class AbstractCameraData(ABC):
 
     def get_smokedetector(self, smoke_id: str) -> dict | None:
         """Get smoke detector."""
-        for home_id in self.smoke_detectors:
-            if smoke_id in self.smoke_detectors[home_id]:
-                return self.smoke_detectors[home_id][smoke_id]
-
-        return None
+        return next(
+            (
+                self.smoke_detectors[home_id][smoke_id]
+                for home_id in self.smoke_detectors
+                if smoke_id in self.smoke_detectors[home_id]
+            ),
+            None,
+        )
 
     def camera_urls(self, camera_id: str) -> tuple[str | None, str | None]:
         """
@@ -155,11 +164,14 @@ class AbstractCameraData(ABC):
 
     def get_person_id(self, name: str, home_id: str) -> str | None:
         """Retrieve the ID of a person."""
-        for pid, data in self.persons[home_id].items():
-            if name == data.get("pseudo"):
-                return pid
-
-        return None
+        return next(
+            (
+                pid
+                for pid, data in self.persons[home_id].items()
+                if name == data.get("pseudo")
+            ),
+            None,
+        )
 
     def build_event_id(self, event_id: str | None, device_type: str | None):
         """Build event id."""
@@ -482,8 +494,7 @@ class CameraData(AbstractCameraData):
             return
 
         if (vpn_url := camera_data.get("vpn_url")) and camera_data.get("is_local"):
-            temp_local_url = self._check_url(vpn_url)
-            if temp_local_url:
+            if temp_local_url := self._check_url(vpn_url):
                 self.cameras[home_id][camera_id]["local_url"] = self._check_url(
                     temp_local_url,
                 )

--- a/src/pyatmo/camera.py
+++ b/src/pyatmo/camera.py
@@ -114,11 +114,7 @@ class AbstractCameraData(ABC):
     def get_camera_home_id(self, camera_id: str) -> str | None:
         """Get camera data."""
         return next(
-            (
-                home_id
-                for home_id in self.cameras
-                if camera_id in self.cameras[home_id]
-            ),
+            (home_id for home_id in self.cameras if camera_id in self.cameras[home_id]),
             None,
         )
 
@@ -469,7 +465,8 @@ class CameraData(AbstractCameraData):
     def update(self, events: int = 30) -> None:
         """Fetch and process data from API."""
         resp = self.auth.post_api_request(
-            endpoint=_GETHOMEDATA_ENDPOINT, params={"size": events}
+            endpoint=_GETHOMEDATA_ENDPOINT,
+            params={"size": events},
         )
 
         self.raw_data = extract_raw_data(resp.json(), "homes")
@@ -542,7 +539,8 @@ class CameraData(AbstractCameraData):
 
         try:
             resp = self.auth.post_api_request(
-                endpoint=_SETSTATE_ENDPOINT, params=post_params
+                endpoint=_SETSTATE_ENDPOINT,
+                params=post_params,
             ).json()
         except ApiError as err_msg:
             LOG.error("%s", err_msg)

--- a/src/pyatmo/climate.py
+++ b/src/pyatmo/climate.py
@@ -132,11 +132,7 @@ class NetatmoHome:
     def get_selected_schedule(self) -> NetatmoSchedule | None:
         """Return selected schedule for given home."""
         return next(
-            (
-                schedule
-                for schedule in self.schedules.values()
-                if schedule.selected
-            ),
+            (schedule for schedule in self.schedules.values() if schedule.selected),
             None,
         )
 

--- a/src/pyatmo/climate.py
+++ b/src/pyatmo/climate.py
@@ -11,11 +11,11 @@ from .auth import AbstractAsyncAuth, NetatmoOAuth2
 from .exceptions import NoSchedule
 from .helpers import extract_raw_data_new
 from .thermostat import (
-    _GETHOMESDATA_REQ,
-    _GETHOMESTATUS_REQ,
-    _SETROOMTHERMPOINT_REQ,
-    _SETTHERMMODE_REQ,
-    _SWITCHHOMESCHEDULE_REQ,
+    _GETHOMESDATA_ENDPOINT,
+    _GETHOMESTATUS_ENDPOINT,
+    _SETROOMTHERMPOINT_ENDPOINT,
+    _SETTHERMMODE_ENDPOINT,
+    _SWITCHHOMESCHEDULE_ENDPOINT,
 )
 
 LOG = logging.getLogger(__name__)
@@ -336,8 +336,8 @@ class AsyncClimate(AbstractClimate):
 
     async def async_update(self) -> None:
         """Fetch and process data from API."""
-        resp = await self.auth.async_post_request(
-            url=_GETHOMESTATUS_REQ,
+        resp = await self.auth.async_post_api_request(
+            endpoint=_GETHOMESTATUS_ENDPOINT,
             params={"home_id": self.home_id},
         )
         raw_data = extract_raw_data_new(await resp.json(), "home")
@@ -370,8 +370,8 @@ class AsyncClimate(AbstractClimate):
             temp,
             end_time,
         )
-        resp = await self.auth.async_post_request(
-            url=_SETROOMTHERMPOINT_REQ,
+        resp = await self.auth.async_post_api_request(
+            endpoint=_SETROOMTHERMPOINT_ENDPOINT,
             params=post_params,
         )
         assert not isinstance(resp, bytes)
@@ -400,8 +400,8 @@ class AsyncClimate(AbstractClimate):
             post_params["schedule_id"] = schedule_id
 
         LOG.debug("Setting home (%s) mode to %s (%s)", self.home_id, mode, schedule_id)
-        resp = await self.auth.async_post_request(
-            url=_SETTHERMMODE_REQ,
+        resp = await self.auth.async_post_api_request(
+            endpoint=_SETTHERMMODE_ENDPOINT,
             params=post_params,
         )
         assert not isinstance(resp, bytes)
@@ -413,8 +413,8 @@ class AsyncClimate(AbstractClimate):
             raise NoSchedule(f"{schedule_id} is not a valid schedule id")
 
         LOG.debug("Setting home (%s) schedule to %s", self.home_id, schedule_id)
-        resp = await self.auth.async_post_request(
-            url=_SWITCHHOMESCHEDULE_REQ,
+        resp = await self.auth.async_post_api_request(
+            endpoint=_SWITCHHOMESCHEDULE_ENDPOINT,
             params={"home_id": self.home_id, "schedule_id": schedule_id},
         )
         LOG.debug("Response: %s", resp)
@@ -437,7 +437,7 @@ class Climate(AbstractClimate):
             LOG.debug('Topology for home "{self.home_id}" has not been initialized.')
             return
 
-        resp = self.auth.post_request(url=_GETHOMESTATUS_REQ)
+        resp = self.auth.post_api_request(endpoint=_GETHOMESTATUS_ENDPOINT)
 
         raw_data = extract_raw_data_new(resp.json(), "home")
         self.process(raw_data)
@@ -489,7 +489,7 @@ class AsyncClimateTopology(AbstractClimateTopology):
 
     async def async_update(self) -> None:
         """Retrieve status updates from /homesdata."""
-        resp = await self.auth.async_post_request(url=_GETHOMESDATA_REQ)
+        resp = await self.auth.async_post_api_request(endpoint=_GETHOMESDATA_ENDPOINT)
         self.raw_data = extract_raw_data_new(await resp.json(), "homes")
 
         for home in self.raw_data["homes"]:

--- a/src/pyatmo/climate.py
+++ b/src/pyatmo/climate.py
@@ -131,10 +131,14 @@ class NetatmoHome:
 
     def get_selected_schedule(self) -> NetatmoSchedule | None:
         """Return selected schedule for given home."""
-        for schedule in self.schedules.values():
-            if schedule.selected:
-                return schedule
-        return None
+        return next(
+            (
+                schedule
+                for schedule in self.schedules.values()
+                if schedule.selected
+            ),
+            None,
+        )
 
     def is_valid_schedule(self, schedule_id: str) -> bool:
         """Check if valid schedule."""

--- a/src/pyatmo/helpers.py
+++ b/src/pyatmo/helpers.py
@@ -30,7 +30,7 @@ def to_time_string(value: str) -> str:
 
 
 def to_epoch(value: str) -> int:
-    return timegm(time.strptime(value + "GMT", "%Y-%m-%d_%H:%M:%S%Z"))
+    return timegm(time.strptime(f"{value}GMT", "%Y-%m-%d_%H:%M:%S%Z"))
 
 
 def today_stamps() -> tuple[int, int]:

--- a/src/pyatmo/helpers.py
+++ b/src/pyatmo/helpers.py
@@ -11,7 +11,7 @@ from .exceptions import NoDevice
 
 LOG: logging.Logger = logging.getLogger(__name__)
 
-_BASE_URL: str = "https://api.netatmo.com/"
+_DEFAULT_BASE_URL: str = "https://api.netatmo.com/"
 
 ERRORS: dict[int, str] = {
     400: "Bad request",

--- a/src/pyatmo/home_coach.py
+++ b/src/pyatmo/home_coach.py
@@ -1,8 +1,7 @@
 from .auth import AbstractAsyncAuth, NetatmoOAuth2
-from .helpers import _BASE_URL
 from .weather_station import AsyncWeatherStationData, WeatherStationData
 
-_GETHOMECOACHDATA_REQ = _BASE_URL + "api/gethomecoachsdata"
+_GETHOMECOACHDATA_ENDPOINT = "api/gethomecoachsdata"
 
 
 class HomeCoachData(WeatherStationData):
@@ -16,7 +15,7 @@ class HomeCoachData(WeatherStationData):
         Arguments:
             auth {NetatmoOAuth2} -- Authentication information with a valid access token
         """
-        super().__init__(auth, url_req=_GETHOMECOACHDATA_REQ, favorites=False)
+        super().__init__(auth, endpoint=_GETHOMECOACHDATA_ENDPOINT, favorites=False)
 
 
 class AsyncHomeCoachData(AsyncWeatherStationData):
@@ -30,4 +29,4 @@ class AsyncHomeCoachData(AsyncWeatherStationData):
         Arguments:
             auth {AbstractAsyncAuth} -- Authentication information with a valid access token
         """
-        super().__init__(auth, url_req=_GETHOMECOACHDATA_REQ, favorites=False)
+        super().__init__(auth, endpoint=_GETHOMECOACHDATA_ENDPOINT, favorites=False)

--- a/src/pyatmo/public_data.py
+++ b/src/pyatmo/public_data.py
@@ -182,7 +182,9 @@ class PublicData(AbstractPublicData):
         if self.required_data_type:
             post_params["required_data"] = self.required_data_type
 
-        resp = self.auth.post_api_request(endpoint=_GETPUBLIC_DATA_ENDPOINT, params=post_params).json()
+        resp = self.auth.post_api_request(
+            endpoint=_GETPUBLIC_DATA_ENDPOINT, params=post_params
+        ).json()
         try:
             self.raw_data = resp["body"]
         except (KeyError, TypeError) as exc:

--- a/src/pyatmo/public_data.py
+++ b/src/pyatmo/public_data.py
@@ -8,9 +8,8 @@ from typing import Any
 
 from .auth import AbstractAsyncAuth, NetatmoOAuth2
 from .exceptions import NoDevice
-from .helpers import _BASE_URL
 
-_GETPUBLIC_DATA = _BASE_URL + "api/getpublicdata"
+_GETPUBLIC_DATA_ENDPOINT = "api/getpublicdata"
 
 _STATION_TEMPERATURE_TYPE = "temperature"
 _STATION_PRESSURE_TYPE = "pressure"
@@ -183,7 +182,7 @@ class PublicData(AbstractPublicData):
         if self.required_data_type:
             post_params["required_data"] = self.required_data_type
 
-        resp = self.auth.post_request(url=_GETPUBLIC_DATA, params=post_params).json()
+        resp = self.auth.post_api_request(endpoint=_GETPUBLIC_DATA_ENDPOINT, params=post_params).json()
         try:
             self.raw_data = resp["body"]
         except (KeyError, TypeError) as exc:
@@ -232,8 +231,8 @@ class AsyncPublicData(AbstractPublicData):
         if self.required_data_type:
             post_params["required_data"] = self.required_data_type
 
-        resp = await self.auth.async_post_request(
-            url=_GETPUBLIC_DATA,
+        resp = await self.auth.async_post_api_request(
+            endpoint=_GETPUBLIC_DATA_ENDPOINT,
             params=post_params,
         )
         assert not isinstance(resp, bytes)

--- a/src/pyatmo/public_data.py
+++ b/src/pyatmo/public_data.py
@@ -183,7 +183,8 @@ class PublicData(AbstractPublicData):
             post_params["required_data"] = self.required_data_type
 
         resp = self.auth.post_api_request(
-            endpoint=_GETPUBLIC_DATA_ENDPOINT, params=post_params
+            endpoint=_GETPUBLIC_DATA_ENDPOINT,
+            params=post_params,
         ).json()
         try:
             self.raw_data = resp["body"]

--- a/src/pyatmo/thermostat.py
+++ b/src/pyatmo/thermostat.py
@@ -8,16 +8,16 @@ from typing import Any
 
 from .auth import AbstractAsyncAuth, NetatmoOAuth2
 from .exceptions import InvalidRoom, NoSchedule
-from .helpers import _BASE_URL, extract_raw_data
+from .helpers import extract_raw_data
 
 LOG = logging.getLogger(__name__)
 
-_GETHOMESDATA_REQ = _BASE_URL + "api/homesdata"
-_GETHOMESTATUS_REQ = _BASE_URL + "api/homestatus"
-_SETTHERMMODE_REQ = _BASE_URL + "api/setthermmode"
-_SETROOMTHERMPOINT_REQ = _BASE_URL + "api/setroomthermpoint"
-_GETROOMMEASURE_REQ = _BASE_URL + "api/getroommeasure"
-_SWITCHHOMESCHEDULE_REQ = _BASE_URL + "api/switchhomeschedule"
+_GETHOMESDATA_ENDPOINT = "api/homesdata"
+_GETHOMESTATUS_ENDPOINT = "api/homestatus"
+_SETTHERMMODE_ENDPOINT = "api/setthermmode"
+_SETROOMTHERMPOINT_ENDPOINT = "api/setroomthermpoint"
+_GETROOMMEASURE_ENDPOINT = "api/getroommeasure"
+_SWITCHHOMESCHEDULE_ENDPOINT = "api/switchhomeschedule"
 
 
 class AbstractHomeData(ABC):
@@ -110,7 +110,7 @@ class HomeData(AbstractHomeData):
 
     def update(self) -> None:
         """Fetch and process data from API."""
-        resp = self.auth.post_request(url=_GETHOMESDATA_REQ)
+        resp = self.auth.post_api_request(endpoint=_GETHOMESDATA_ENDPOINT)
 
         self.raw_data = extract_raw_data(resp.json(), "homes")
         self.process()
@@ -121,7 +121,7 @@ class HomeData(AbstractHomeData):
             raise NoSchedule(f"{schedule_id} is not a valid schedule id")
 
         post_params = {"home_id": home_id, "schedule_id": schedule_id}
-        resp = self.auth.post_request(url=_SWITCHHOMESCHEDULE_REQ, params=post_params)
+        resp = self.auth.post_api_request(endpoint=_SWITCHHOMESCHEDULE_ENDPOINT, params=post_params)
         LOG.debug("Response: %s", resp)
 
 
@@ -138,7 +138,7 @@ class AsyncHomeData(AbstractHomeData):
 
     async def async_update(self):
         """Fetch and process data from API."""
-        resp = await self.auth.async_post_request(url=_GETHOMESDATA_REQ)
+        resp = await self.auth.async_post_api_request(endpoint=_GETHOMESDATA_ENDPOINT)
 
         assert not isinstance(resp, bytes)
         self.raw_data = extract_raw_data(await resp.json(), "homes")
@@ -149,8 +149,8 @@ class AsyncHomeData(AbstractHomeData):
         if not self.is_valid_schedule(home_id, schedule_id):
             raise NoSchedule(f"{schedule_id} is not a valid schedule id")
 
-        resp = await self.auth.async_post_request(
-            url=_SWITCHHOMESCHEDULE_REQ,
+        resp = await self.auth.async_post_api_request(
+            endpoint=_SWITCHHOMESCHEDULE_ENDPOINT,
             params={"home_id": home_id, "schedule_id": schedule_id},
         )
         LOG.debug("Response: %s", resp)
@@ -244,8 +244,8 @@ class HomeStatus(AbstractHomeStatus):
 
     def update(self) -> None:
         """Fetch and process data from API."""
-        resp = self.auth.post_request(
-            url=_GETHOMESTATUS_REQ,
+        resp = self.auth.post_api_request(
+            endpoint=_GETHOMESTATUS_ENDPOINT,
             params={"home_id": self.home_id},
         )
 
@@ -266,7 +266,7 @@ class HomeStatus(AbstractHomeStatus):
         if schedule_id is not None and mode == "schedule":
             post_params["schedule_id"] = schedule_id
 
-        return self.auth.post_request(url=_SETTHERMMODE_REQ, params=post_params).json()
+        return self.auth.post_api_request(endpoint=_SETTHERMMODE_ENDPOINT, params=post_params).json()
 
     def set_room_thermpoint(
         self,
@@ -285,8 +285,8 @@ class HomeStatus(AbstractHomeStatus):
         if end_time is not None:
             post_params["endtime"] = str(end_time)
 
-        return self.auth.post_request(
-            url=_SETROOMTHERMPOINT_REQ,
+        return self.auth.post_api_request(
+            endpoint=_SETROOMTHERMPOINT_ENDPOINT,
             params=post_params,
         ).json()
 
@@ -306,8 +306,8 @@ class AsyncHomeStatus(AbstractHomeStatus):
 
     async def async_update(self) -> None:
         """Fetch and process data from API."""
-        resp = await self.auth.async_post_request(
-            url=_GETHOMESTATUS_REQ,
+        resp = await self.auth.async_post_api_request(
+            endpoint=_GETHOMESTATUS_ENDPOINT,
             params={"home_id": self.home_id},
         )
 
@@ -329,8 +329,8 @@ class AsyncHomeStatus(AbstractHomeStatus):
         if schedule_id is not None and mode == "schedule":
             post_params["schedule_id"] = schedule_id
 
-        resp = await self.auth.async_post_request(
-            url=_SETTHERMMODE_REQ,
+        resp = await self.auth.async_post_api_request(
+            endpoint=_SETTHERMMODE_ENDPOINT,
             params=post_params,
         )
         assert not isinstance(resp, bytes)
@@ -353,8 +353,8 @@ class AsyncHomeStatus(AbstractHomeStatus):
         if end_time is not None:
             post_params["endtime"] = str(end_time)
 
-        resp = await self.auth.async_post_request(
-            url=_SETROOMTHERMPOINT_REQ,
+        resp = await self.auth.async_post_api_request(
+            endpoint=_SETROOMTHERMPOINT_ENDPOINT,
             params=post_params,
         )
         assert not isinstance(resp, bytes)

--- a/src/pyatmo/thermostat.py
+++ b/src/pyatmo/thermostat.py
@@ -128,7 +128,8 @@ class HomeData(AbstractHomeData):
 
         post_params = {"home_id": home_id, "schedule_id": schedule_id}
         resp = self.auth.post_api_request(
-            endpoint=_SWITCHHOMESCHEDULE_ENDPOINT, params=post_params
+            endpoint=_SWITCHHOMESCHEDULE_ENDPOINT,
+            params=post_params,
         )
         LOG.debug("Response: %s", resp)
 
@@ -275,7 +276,8 @@ class HomeStatus(AbstractHomeStatus):
             post_params["schedule_id"] = schedule_id
 
         return self.auth.post_api_request(
-            endpoint=_SETTHERMMODE_ENDPOINT, params=post_params
+            endpoint=_SETTHERMMODE_ENDPOINT,
+            params=post_params,
         ).json()
 
     def set_room_thermpoint(

--- a/src/pyatmo/thermostat.py
+++ b/src/pyatmo/thermostat.py
@@ -67,11 +67,14 @@ class AbstractHomeData(ABC):
 
     def _get_selected_schedule(self, home_id: str) -> dict:
         """Get the selected schedule for a given home ID."""
-        for value in self.schedules.get(home_id, {}).values():
-            if "selected" in value.keys():
-                return value
-
-        return {}
+        return next(
+            (
+                value
+                for value in self.schedules.get(home_id, {}).values()
+                if "selected" in value.keys()
+            ),
+            {},
+        )
 
     def get_hg_temp(self, home_id: str) -> float | None:
         """Return frost guard temperature value."""
@@ -83,11 +86,14 @@ class AbstractHomeData(ABC):
 
     def get_thermostat_type(self, home_id: str, room_id: str) -> str | None:
         """Return the thermostat type of the room."""
-        for module in self.modules.get(home_id, {}).values():
-            if module.get("room_id") == room_id:
-                return module.get("type")
-
-        return None
+        return next(
+            (
+                module.get("type")
+                for module in self.modules.get(home_id, {}).values()
+                if module.get("room_id") == room_id
+            ),
+            None,
+        )
 
     def is_valid_schedule(self, home_id: str, schedule_id: str):
         """Check if valid schedule."""

--- a/src/pyatmo/thermostat.py
+++ b/src/pyatmo/thermostat.py
@@ -121,7 +121,9 @@ class HomeData(AbstractHomeData):
             raise NoSchedule(f"{schedule_id} is not a valid schedule id")
 
         post_params = {"home_id": home_id, "schedule_id": schedule_id}
-        resp = self.auth.post_api_request(endpoint=_SWITCHHOMESCHEDULE_ENDPOINT, params=post_params)
+        resp = self.auth.post_api_request(
+            endpoint=_SWITCHHOMESCHEDULE_ENDPOINT, params=post_params
+        )
         LOG.debug("Response: %s", resp)
 
 
@@ -266,7 +268,9 @@ class HomeStatus(AbstractHomeStatus):
         if schedule_id is not None and mode == "schedule":
             post_params["schedule_id"] = schedule_id
 
-        return self.auth.post_api_request(endpoint=_SETTHERMMODE_ENDPOINT, params=post_params).json()
+        return self.auth.post_api_request(
+            endpoint=_SETTHERMMODE_ENDPOINT, params=post_params
+        ).json()
 
     def set_room_thermpoint(
         self,

--- a/src/pyatmo/weather_station.py
+++ b/src/pyatmo/weather_station.py
@@ -216,7 +216,8 @@ class WeatherStationData(AbstractWeatherStationData):
         """Fetch data from API."""
         self.raw_data = extract_raw_data(
             self.auth.post_api_request(
-                endpoint=self.endpoint, params=self.params
+                endpoint=self.endpoint,
+                params=self.params,
             ).json(),
             "devices",
         )
@@ -255,7 +256,8 @@ class WeatherStationData(AbstractWeatherStationData):
         post_params["real_time"] = "true" if real_time else "false"
 
         return self.auth.post_api_request(
-            endpoint=_GETMEASURE_ENDPOINT, params=post_params
+            endpoint=_GETMEASURE_ENDPOINT,
+            params=post_params,
         ).json()
 
     def get_min_max_t_h(
@@ -323,7 +325,8 @@ class AsyncWeatherStationData(AbstractWeatherStationData):
     async def async_update(self):
         """Fetch data from API."""
         resp = await self.auth.async_post_api_request(
-            endpoint=self.endpoint, params=self.params
+            endpoint=self.endpoint,
+            params=self.params,
         )
 
         assert not isinstance(resp, bytes)

--- a/src/pyatmo/weather_station.py
+++ b/src/pyatmo/weather_station.py
@@ -44,12 +44,10 @@ class AbstractWeatherStationData(ABC):
 
     def get_module_names(self, station_id: str) -> list:
         """Return a list of all module names for a given station."""
-        res = set()
-
         if not (station_data := self.get_station(station_id)):
             return []
 
-        res.add(station_data.get("module_name", station_data.get("type")))
+        res = {station_data.get("module_name", station_data.get("type"))}
         for module in station_data["modules"]:
             # Add module name, use module type if no name is available
             res.add(module.get("module_name", module.get("type")))
@@ -288,16 +286,14 @@ class WeatherStationData(AbstractWeatherStationData):
         else:
             raise ValueError("'frame' value can only be 'last24' or 'day'")
 
-        resp = self.get_data(
+        if resp := self.get_data(
             device_id=station_id,
             module_id=module_id,
             scale="max",
             module_type="Temperature,Humidity",
             date_begin=start,
             date_end=end,
-        )
-
-        if resp:
+        ):
             temperature = [temp[0] for temp in resp["body"].values()]
             humidity = [hum[1] for hum in resp["body"].values()]
             return min(temperature), max(temperature), min(humidity), max(humidity)

--- a/src/pyatmo/weather_station.py
+++ b/src/pyatmo/weather_station.py
@@ -7,7 +7,7 @@ from abc import ABC
 from collections import defaultdict
 
 from .auth import AbstractAsyncAuth, NetatmoOAuth2
-from .helpers import _DEFAULT_BASE_URL, extract_raw_data, today_stamps
+from .helpers import extract_raw_data, today_stamps
 
 LOG = logging.getLogger(__name__)
 

--- a/src/pyatmo/weather_station.py
+++ b/src/pyatmo/weather_station.py
@@ -217,7 +217,9 @@ class WeatherStationData(AbstractWeatherStationData):
     def update(self):
         """Fetch data from API."""
         self.raw_data = extract_raw_data(
-            self.auth.post_api_request(endpoint=self.endpoint, params=self.params).json(),
+            self.auth.post_api_request(
+                endpoint=self.endpoint, params=self.params
+            ).json(),
             "devices",
         )
         self.process()
@@ -254,7 +256,9 @@ class WeatherStationData(AbstractWeatherStationData):
         post_params["optimize"] = "true" if optimize else "false"
         post_params["real_time"] = "true" if real_time else "false"
 
-        return self.auth.post_api_request(endpoint=_GETMEASURE_ENDPOINT, params=post_params).json()
+        return self.auth.post_api_request(
+            endpoint=_GETMEASURE_ENDPOINT, params=post_params
+        ).json()
 
     def get_min_max_t_h(
         self,
@@ -322,7 +326,9 @@ class AsyncWeatherStationData(AbstractWeatherStationData):
 
     async def async_update(self):
         """Fetch data from API."""
-        resp = await self.auth.async_post_api_request(endpoint=self.endpoint, params=self.params)
+        resp = await self.auth.async_post_api_request(
+            endpoint=self.endpoint, params=self.params
+        )
 
         assert not isinstance(resp, bytes)
         self.raw_data = extract_raw_data(await resp.json(), "devices")

--- a/src/pyatmo/weather_station.py
+++ b/src/pyatmo/weather_station.py
@@ -7,12 +7,12 @@ from abc import ABC
 from collections import defaultdict
 
 from .auth import AbstractAsyncAuth, NetatmoOAuth2
-from .helpers import _BASE_URL, extract_raw_data, today_stamps
+from .helpers import _DEFAULT_BASE_URL, extract_raw_data, today_stamps
 
 LOG = logging.getLogger(__name__)
 
-_GETMEASURE_REQ = _BASE_URL + "api/getmeasure"
-_GETSTATIONDATA_REQ = _BASE_URL + "api/getstationsdata"
+_GETMEASURE_ENDPOINT = "api/getmeasure"
+_GETSTATIONDATA_ENDPOINT = "api/getstationsdata"
 
 
 class AbstractWeatherStationData(ABC):
@@ -201,7 +201,7 @@ class WeatherStationData(AbstractWeatherStationData):
     def __init__(
         self,
         auth: NetatmoOAuth2,
-        url_req: str = _GETSTATIONDATA_REQ,
+        endpoint: str = _GETSTATIONDATA_ENDPOINT,
         favorites: bool = True,
     ) -> None:
         """Initialize the Netatmo weather station data.
@@ -211,13 +211,13 @@ class WeatherStationData(AbstractWeatherStationData):
             url_req {str} -- Optional request endpoint
         """
         self.auth = auth
-        self.url_req = url_req
+        self.endpoint = endpoint
         self.params = {"get_favorites": ("true" if favorites else "false")}
 
     def update(self):
         """Fetch data from API."""
         self.raw_data = extract_raw_data(
-            self.auth.post_request(url=self.url_req, params=self.params).json(),
+            self.auth.post_api_request(endpoint=self.endpoint, params=self.params).json(),
             "devices",
         )
         self.process()
@@ -254,7 +254,7 @@ class WeatherStationData(AbstractWeatherStationData):
         post_params["optimize"] = "true" if optimize else "false"
         post_params["real_time"] = "true" if real_time else "false"
 
-        return self.auth.post_request(url=_GETMEASURE_REQ, params=post_params).json()
+        return self.auth.post_api_request(endpoint=_GETMEASURE_ENDPOINT, params=post_params).json()
 
     def get_min_max_t_h(
         self,
@@ -307,7 +307,7 @@ class AsyncWeatherStationData(AbstractWeatherStationData):
     def __init__(
         self,
         auth: AbstractAsyncAuth,
-        url_req: str = _GETSTATIONDATA_REQ,
+        endpoint: str = _GETSTATIONDATA_ENDPOINT,
         favorites: bool = True,
     ) -> None:
         """Initialize the Netatmo weather station data.
@@ -317,12 +317,12 @@ class AsyncWeatherStationData(AbstractWeatherStationData):
             url_req {str} -- Optional request endpoint
         """
         self.auth = auth
-        self.url_req = url_req
+        self.endpoint = endpoint
         self.params = {"get_favorites": ("true" if favorites else "false")}
 
     async def async_update(self):
         """Fetch data from API."""
-        resp = await self.auth.async_post_request(url=self.url_req, params=self.params)
+        resp = await self.auth.async_post_api_request(endpoint=self.endpoint, params=self.params)
 
         assert not isinstance(resp, bytes)
         self.raw_data = extract_raw_data(await resp.json(), "devices")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,7 +111,8 @@ def weather_station_data(auth, requests_mock):
     ) as json_file:
         json_fixture = json.load(json_file)
     requests_mock.post(
-        pyatmo.helpers._DEFAULT_BASE_URL + pyatmo.weather_station._GETSTATIONDATA_ENDPOINT,
+        pyatmo.helpers._DEFAULT_BASE_URL
+        + pyatmo.weather_station._GETSTATIONDATA_ENDPOINT,
         json=json_fixture,
         headers={"content-type": "application/json"},
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -148,15 +148,16 @@ def camera_ping(requests_mock):
         with open("fixtures/camera_ping.json", encoding="utf-8") as json_file:
             json_fixture = json.load(json_file)
         requests_mock.post(
-            vpn_url + "/command/ping",
+            f"{vpn_url}/command/ping",
             json=json_fixture,
             headers={"content-type": "application/json"},
         )
+
     local_url = "http://192.168.0.123/678460a0d47e5618699fb31169e2b47d"
     with open("fixtures/camera_ping.json", encoding="utf-8") as json_file:
         json_fixture = json.load(json_file)
     requests_mock.post(
-        local_url + "/command/ping",
+        f"{local_url}/command/ping",
         json=json_fixture,
         headers={"content-type": "application/json"},
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,7 +38,7 @@ def auth(requests_mock):
     with open("fixtures/oauth2_token.json", encoding="utf-8") as json_file:
         json_fixture = json.load(json_file)
     requests_mock.post(
-        pyatmo.auth.AUTH_REQ,
+        pyatmo.helpers._DEFAULT_BASE_URL + pyatmo.auth.AUTH_REQ_ENDPOINT,
         json=json_fixture,
         headers={"content-type": "application/json"},
     )
@@ -57,7 +57,7 @@ def home_data(auth, requests_mock):
     with open("fixtures/home_data_simple.json", encoding="utf-8") as json_file:
         json_fixture = json.load(json_file)
     requests_mock.post(
-        pyatmo.thermostat._GETHOMESDATA_REQ,
+        pyatmo.helpers._DEFAULT_BASE_URL + pyatmo.thermostat._GETHOMESDATA_ENDPOINT,
         json=json_fixture,
         headers={"content-type": "application/json"},
     )
@@ -72,7 +72,7 @@ def home_status(auth, home_id, requests_mock):
     with open("fixtures/home_status_simple.json", encoding="utf-8") as json_file:
         json_fixture = json.load(json_file)
     requests_mock.post(
-        pyatmo.thermostat._GETHOMESTATUS_REQ,
+        pyatmo.helpers._DEFAULT_BASE_URL + pyatmo.thermostat._GETHOMESTATUS_ENDPOINT,
         json=json_fixture,
         headers={"content-type": "application/json"},
     )
@@ -87,7 +87,7 @@ def public_data(auth, requests_mock):
     with open("fixtures/public_data_simple.json", encoding="utf-8") as json_file:
         json_fixture = json.load(json_file)
     requests_mock.post(
-        pyatmo.public_data._GETPUBLIC_DATA,
+        pyatmo.helpers._DEFAULT_BASE_URL + pyatmo.public_data._GETPUBLIC_DATA_ENDPOINT,
         json=json_fixture,
         headers={"content-type": "application/json"},
     )
@@ -111,7 +111,7 @@ def weather_station_data(auth, requests_mock):
     ) as json_file:
         json_fixture = json.load(json_file)
     requests_mock.post(
-        pyatmo.weather_station._GETSTATIONDATA_REQ,
+        pyatmo.helpers._DEFAULT_BASE_URL + pyatmo.weather_station._GETSTATIONDATA_ENDPOINT,
         json=json_fixture,
         headers={"content-type": "application/json"},
     )
@@ -126,7 +126,7 @@ def home_coach_data(auth, requests_mock):
     with open("fixtures/home_coach_simple.json", encoding="utf-8") as json_file:
         json_fixture = json.load(json_file)
     requests_mock.post(
-        pyatmo.home_coach._GETHOMECOACHDATA_REQ,
+        pyatmo.helpers._DEFAULT_BASE_URL + pyatmo.home_coach._GETHOMECOACHDATA_ENDPOINT,
         json=json_fixture,
         headers={"content-type": "application/json"},
     )
@@ -167,7 +167,7 @@ def camera_home_data(auth, camera_ping, requests_mock):  # pylint: disable=W0613
     with open("fixtures/camera_home_data.json", encoding="utf-8") as json_file:
         json_fixture = json.load(json_file)
     requests_mock.post(
-        pyatmo.camera._GETHOMEDATA_REQ,
+        pyatmo.helpers._DEFAULT_BASE_URL + pyatmo.camera._GETHOMEDATA_ENDPOINT,
         json=json_fixture,
         headers={"content-type": "application/json"},
     )
@@ -192,7 +192,7 @@ async def async_camera_home_data(async_auth):
     mock_resp = MockResponse(json_fixture, 200)
 
     with patch(
-        "pyatmo.auth.AbstractAsyncAuth.async_post_request",
+        "pyatmo.auth.AbstractAsyncAuth.async_post_api_request",
         AsyncMock(return_value=mock_resp),
     ) as mock_request:
         camera_data = pyatmo.AsyncCameraData(async_auth)
@@ -211,7 +211,7 @@ async def async_home_coach_data(async_auth):
     mock_resp = MockResponse(json_fixture, 200)
 
     with patch(
-        "pyatmo.auth.AbstractAsyncAuth.async_post_request",
+        "pyatmo.auth.AbstractAsyncAuth.async_post_api_request",
         AsyncMock(return_value=mock_resp),
     ) as mock_request:
         hcd = pyatmo.AsyncHomeCoachData(async_auth)
@@ -230,7 +230,7 @@ async def async_home_data(async_auth):
     mock_resp = MockResponse(json_fixture, 200)
 
     with patch(
-        "pyatmo.auth.AbstractAsyncAuth.async_post_request",
+        "pyatmo.auth.AbstractAsyncAuth.async_post_api_request",
         AsyncMock(return_value=mock_resp),
     ) as mock_request:
         home_data = pyatmo.AsyncHomeData(async_auth)
@@ -249,7 +249,7 @@ async def async_home_status(async_auth, home_id):
     mock_resp = MockResponse(json_fixture, 200)
 
     with patch(
-        "pyatmo.auth.AbstractAsyncAuth.async_post_request",
+        "pyatmo.auth.AbstractAsyncAuth.async_post_api_request",
         AsyncMock(return_value=mock_resp),
     ) as mock_request:
         home_status = pyatmo.AsyncHomeStatus(async_auth, home_id)
@@ -271,7 +271,7 @@ async def async_weather_station_data(async_auth):
     mock_resp = MockResponse(json_fixture, 200)
 
     with patch(
-        "pyatmo.auth.AbstractAsyncAuth.async_post_request",
+        "pyatmo.auth.AbstractAsyncAuth.async_post_api_request",
         AsyncMock(return_value=mock_resp),
     ) as mock_request:
         wsd = pyatmo.AsyncWeatherStationData(async_auth)
@@ -291,7 +291,7 @@ async def async_climate_topology(async_auth):
     mock_home_data_resp = MockResponse(home_data_fixture, 200)
 
     with patch(
-        "pyatmo.auth.AbstractAsyncAuth.async_post_request",
+        "pyatmo.auth.AbstractAsyncAuth.async_post_api_request",
         AsyncMock(return_value=mock_home_data_resp),
     ):
         await climate_topology.async_update()
@@ -310,7 +310,7 @@ async def async_climate(async_auth, async_climate_topology):
     mock_home_status_resp = MockResponse(home_status_fixture, 200)
 
     with patch(
-        "pyatmo.auth.AbstractAsyncAuth.async_post_request",
+        "pyatmo.auth.AbstractAsyncAuth.async_post_api_request",
         AsyncMock(return_value=mock_home_status_resp),
     ):
         await climate.async_update()

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -23,7 +23,7 @@ async def test_async_auth(async_auth, mocker):
     mock_resp = MockResponse(json_fixture, 200)
 
     with patch(
-        "pyatmo.auth.AbstractAsyncAuth.async_post_request",
+        "pyatmo.auth.AbstractAsyncAuth.async_post_api_request",
         AsyncMock(return_value=mock_resp),
     ) as mock_request:
         camera_data = pyatmo.AsyncCameraData(async_auth)
@@ -44,7 +44,7 @@ async def test_async_home_data_no_body(async_auth):
         json_fixture = json.load(fixture_file)
 
     with patch(
-        "pyatmo.auth.AbstractAsyncAuth.async_post_request",
+        "pyatmo.auth.AbstractAsyncAuth.async_post_api_request",
         AsyncMock(return_value=json_fixture),
     ) as mock_request:
         camera_data = pyatmo.AsyncCameraData(async_auth)
@@ -63,7 +63,7 @@ async def test_async_home_data_no_homes(async_auth):
         json_fixture = json.load(fixture_file)
 
     with patch(
-        "pyatmo.auth.AbstractAsyncAuth.async_post_request",
+        "pyatmo.auth.AbstractAsyncAuth.async_post_api_request",
         AsyncMock(return_value=json_fixture),
     ) as mock_request:
         camera_data = pyatmo.AsyncCameraData(async_auth)
@@ -88,7 +88,7 @@ async def test_async_public_data(async_auth):
     mock_resp = MockResponse(json_fixture, 200)
 
     with patch(
-        "pyatmo.auth.AbstractAsyncAuth.async_post_request",
+        "pyatmo.auth.AbstractAsyncAuth.async_post_api_request",
         AsyncMock(return_value=mock_resp),
     ) as mock_request:
         public_data = pyatmo.AsyncPublicData(async_auth, LAT_NE, LON_NE, LAT_SW, LON_SW)
@@ -117,7 +117,7 @@ async def test_async_public_data_error(async_auth):
     mock_resp = MockResponse(json_fixture, 200)
 
     with patch(
-        "pyatmo.auth.AbstractAsyncAuth.async_post_request",
+        "pyatmo.auth.AbstractAsyncAuth.async_post_api_request",
         AsyncMock(return_value=mock_resp),
     ):
 
@@ -181,7 +181,7 @@ async def test_async_home_data_no_data(async_auth):
     mock_resp = MockResponse(None, 200)
 
     with patch(
-        "pyatmo.auth.AbstractAsyncAuth.async_post_request",
+        "pyatmo.auth.AbstractAsyncAuth.async_post_api_request",
         AsyncMock(return_value=mock_resp),
     ):
         with pytest.raises(pyatmo.NoDevice):
@@ -197,7 +197,7 @@ async def test_async_data_no_body(async_auth):
     mock_resp = MockResponse(json_fixture, 200)
 
     with patch(
-        "pyatmo.auth.AbstractAsyncAuth.async_post_request",
+        "pyatmo.auth.AbstractAsyncAuth.async_post_api_request",
         AsyncMock(return_value=mock_resp),
     ):
         home_data = pyatmo.AsyncHomeData(async_auth)
@@ -227,7 +227,7 @@ async def test_async_home_data_switch_home_schedule(
         json_fixture = json.load(json_file)
 
     with patch(
-        "pyatmo.auth.AbstractAsyncAuth.async_post_request",
+        "pyatmo.auth.AbstractAsyncAuth.async_post_api_request",
         AsyncMock(return_value=json_fixture),
     ):
         with expected:
@@ -339,7 +339,7 @@ async def test_async_home_status_set_thermmode(
     mock_resp = MockResponse(json_fixture, 200)
 
     with patch(
-        "pyatmo.auth.AbstractAsyncAuth.async_post_request",
+        "pyatmo.auth.AbstractAsyncAuth.async_post_api_request",
         AsyncMock(return_value=mock_resp),
     ):
         res = await async_home_status.async_set_thermmode(
@@ -410,7 +410,7 @@ async def test_async_home_status_set_room_thermpoint(
     mock_resp = MockResponse(json_fixture, 200)
 
     with patch(
-        "pyatmo.auth.AbstractAsyncAuth.async_post_request",
+        "pyatmo.auth.AbstractAsyncAuth.async_post_api_request",
         AsyncMock(return_value=mock_resp),
     ):
         result = await async_home_status.async_set_room_thermpoint(
@@ -519,7 +519,7 @@ async def test_async_camera_data_set_persons_away(
     with open(f"fixtures/{json_fixture}", encoding="utf-8") as json_file:
         json_fixture = json.load(json_file)
     with patch(
-        "pyatmo.auth.AbstractAsyncAuth.async_post_request",
+        "pyatmo.auth.AbstractAsyncAuth.async_post_api_request",
         AsyncMock(return_value=json_fixture),
     ) as mock_req:
         result = await async_camera_home_data.async_set_persons_away(home_id, person_id)
@@ -531,14 +531,14 @@ async def test_async_camera_data_set_persons_away(
                 "home_id": home_id,
                 "person_id": person_id,
             },
-            url="https://api.netatmo.com/api/setpersonsaway",
+            endpoint="api/setpersonsaway",
         )
     else:
         mock_req.assert_called_once_with(
             params={
                 "home_id": home_id,
             },
-            url="https://api.netatmo.com/api/setpersonsaway",
+            endpoint="api/setpersonsaway",
         )
 
 
@@ -579,7 +579,7 @@ async def test_async_camera_data_set_persons_home(
     with open(f"fixtures/{json_fixture}", encoding="utf-8") as json_file:
         json_fixture = json.load(json_file)
     with patch(
-        "pyatmo.auth.AbstractAsyncAuth.async_post_request",
+        "pyatmo.auth.AbstractAsyncAuth.async_post_api_request",
         AsyncMock(return_value=json_fixture),
     ) as mock_req:
         result = await async_camera_home_data.async_set_persons_home(
@@ -594,12 +594,12 @@ async def test_async_camera_data_set_persons_home(
                 "home_id": home_id,
                 "person_ids[]": person_ids,
             },
-            url="https://api.netatmo.com/api/setpersonshome",
+            endpoint="api/setpersonshome",
         )
     else:
         mock_req.assert_called_once_with(
             params={
                 "home_id": home_id,
             },
-            url="https://api.netatmo.com/api/setpersonshome",
+            endpoint="api/setpersonshome",
         )

--- a/tests/test_pyatmo.py
+++ b/tests/test_pyatmo.py
@@ -22,7 +22,7 @@ def test_client_auth_invalid(requests_mock):
     with open("fixtures/invalid_grant.json", encoding="utf-8") as json_file:
         json_fixture = json.load(json_file)
     requests_mock.post(
-        pyatmo.auth.AUTH_REQ,
+        pyatmo.helpers._DEFAULT_BASE_URL + pyatmo.auth.AUTH_REQ_ENDPOINT,
         json=json_fixture,
         headers={"content-type": "application/json"},
     )
@@ -38,36 +38,36 @@ def test_client_auth_invalid(requests_mock):
 def test_post_request_json(auth, requests_mock):
     """Test wrapper for posting requests against the Netatmo API."""
     requests_mock.post(
-        pyatmo.helpers._BASE_URL,
+        pyatmo.helpers._DEFAULT_BASE_URL,
         json={"a": "b"},
         headers={"content-type": "application/json"},
     )
-    resp = auth.post_request(pyatmo.helpers._BASE_URL, None).json()
+    resp = auth.post_request(pyatmo.helpers._DEFAULT_BASE_URL, None).json()
     assert resp == {"a": "b"}
 
 
 def test_post_request_binary(auth, requests_mock):
     """Test wrapper for posting requests against the Netatmo API."""
     requests_mock.post(
-        pyatmo.helpers._BASE_URL,
+        pyatmo.helpers._DEFAULT_BASE_URL,
         text="Success",
         headers={"content-type": "application/text"},
     )
-    resp = auth.post_request(pyatmo.helpers._BASE_URL, None).content
+    resp = auth.post_request(pyatmo.helpers._DEFAULT_BASE_URL, None).content
     assert resp == b"Success"
 
 
 @pytest.mark.parametrize("test_input,expected", [(200, None), (404, None), (401, None)])
 def test_post_request_fail(auth, requests_mock, test_input, expected):
     """Test failing requests against the Netatmo API."""
-    requests_mock.post(pyatmo.helpers._BASE_URL, status_code=test_input)
+    requests_mock.post(pyatmo.helpers._DEFAULT_BASE_URL, status_code=test_input)
 
     if test_input == 200:
-        resp = auth.post_request(pyatmo.helpers._BASE_URL, None).content
+        resp = auth.post_request(pyatmo.helpers._DEFAULT_BASE_URL, None).content
         assert resp is expected
     else:
         with pytest.raises(pyatmo.ApiError):
-            resp = auth.post_request(pyatmo.helpers._BASE_URL, None).content
+            resp = auth.post_request(pyatmo.helpers._DEFAULT_BASE_URL, None).content
 
 
 @pytest.mark.parametrize(

--- a/tests/test_pyatmo_camera.py
+++ b/tests/test_pyatmo_camera.py
@@ -73,17 +73,19 @@ def test_camera_data_camera_urls(camera_home_data, requests_mock):
     with open("fixtures/camera_ping.json", encoding="utf-8") as json_file:
         json_fixture = json.load(json_file)
     requests_mock.post(
-        vpn_url + "/command/ping",
+        f"{vpn_url}/command/ping",
         json=json_fixture,
         headers={"content-type": "application/json"},
     )
+
     with open("fixtures/camera_ping.json", encoding="utf-8") as json_file:
         json_fixture = json.load(json_file)
     requests_mock.post(
-        local_url + "/command/ping",
+        f"{local_url}/command/ping",
         json=json_fixture,
         headers={"content-type": "application/json"},
     )
+
 
     camera_home_data.update_camera_urls(cid)
 
@@ -372,8 +374,7 @@ def test_camera_data_motion_detected(
     ],
 )
 def test_camera_data_get_smokedetector(camera_home_data, sid, expected):
-    smokedetector = camera_home_data.get_smokedetector(sid)
-    if smokedetector:
+    if smokedetector := camera_home_data.get_smokedetector(sid):
         assert smokedetector["name"] == expected
     else:
         assert smokedetector is expected

--- a/tests/test_pyatmo_camera.py
+++ b/tests/test_pyatmo_camera.py
@@ -468,7 +468,10 @@ def test_camera_data_get_camera_picture(camera_home_data, requests_mock):
     ) as fixture_file:
         expect = fixture_file.read()
 
-    requests_mock.post(pyatmo.helpers._DEFAULT_BASE_URL + pyatmo.camera._GETCAMERAPICTURE_ENDPOINT, content=expect)
+    requests_mock.post(
+        pyatmo.helpers._DEFAULT_BASE_URL + pyatmo.camera._GETCAMERAPICTURE_ENDPOINT,
+        content=expect,
+    )
 
     assert camera_home_data.get_camera_picture(image_id, key) == (expect, "jpeg")
 
@@ -480,7 +483,10 @@ def test_camera_data_get_profile_image(camera_home_data, requests_mock):
     ) as fixture_file:
         expect = fixture_file.read()
 
-    requests_mock.post(pyatmo.helpers._DEFAULT_BASE_URL + pyatmo.camera._GETCAMERAPICTURE_ENDPOINT, content=expect)
+    requests_mock.post(
+        pyatmo.helpers._DEFAULT_BASE_URL + pyatmo.camera._GETCAMERAPICTURE_ENDPOINT,
+        content=expect,
+    )
     assert camera_home_data.get_profile_image(
         "John Doe",
         "91763b24c43d3e344f424e8b",

--- a/tests/test_pyatmo_camera.py
+++ b/tests/test_pyatmo_camera.py
@@ -86,7 +86,6 @@ def test_camera_data_camera_urls(camera_home_data, requests_mock):
         headers={"content-type": "application/json"},
     )
 
-
     camera_home_data.update_camera_urls(cid)
 
     assert camera_home_data.camera_urls(cid) == (vpn_url, local_url)

--- a/tests/test_pyatmo_camera.py
+++ b/tests/test_pyatmo_camera.py
@@ -18,7 +18,7 @@ def test_home_data_no_body(auth, requests_mock):
     with open("fixtures/camera_data_empty.json", encoding="utf-8") as fixture_file:
         json_fixture = json.load(fixture_file)
     requests_mock.post(
-        pyatmo.camera._GETHOMEDATA_REQ,
+        pyatmo.helpers._DEFAULT_BASE_URL + pyatmo.camera._GETHOMEDATA_ENDPOINT,
         json=json_fixture,
         headers={"content-type": "application/json"},
     )
@@ -34,7 +34,7 @@ def test_home_data_no_homes(auth, requests_mock):
     ) as fixture_file:
         json_fixture = json.load(fixture_file)
     requests_mock.post(
-        pyatmo.camera._GETHOMEDATA_REQ,
+        pyatmo.helpers._DEFAULT_BASE_URL + pyatmo.camera._GETHOMEDATA_ENDPOINT,
         json=json_fixture,
         headers={"content-type": "application/json"},
     )
@@ -108,7 +108,7 @@ def test_camera_data_camera_urls_disconnected(auth, camera_ping, requests_mock):
     ) as fixture_file:
         json_fixture = json.load(fixture_file)
     requests_mock.post(
-        pyatmo.camera._GETHOMEDATA_REQ,
+        pyatmo.helpers._DEFAULT_BASE_URL + pyatmo.camera._GETHOMEDATA_ENDPOINT,
         json=json_fixture,
         headers={"content-type": "application/json"},
     )
@@ -228,7 +228,7 @@ def test_camera_data_set_persons_away(
     with open(f"fixtures/{json_fixture}", encoding="utf-8") as json_file:
         json_fixture = json.load(json_file)
     mock_req = requests_mock.post(
-        pyatmo.camera._SETPERSONSAWAY_REQ,
+        pyatmo.helpers._DEFAULT_BASE_URL + pyatmo.camera._SETPERSONSAWAY_ENDPOINT,
         json=json_fixture,
         headers={"content-type": "application/json"},
     )
@@ -279,7 +279,7 @@ def test_camera_data_set_persons_home(
     with open(f"fixtures/{json_fixture}", encoding="utf-8") as json_file:
         json_fixture = json.load(json_file)
     mock_req = requests_mock.post(
-        pyatmo.camera._SETPERSONSHOME_REQ,
+        pyatmo.helpers._DEFAULT_BASE_URL + pyatmo.camera._SETPERSONSHOME_ENDPOINT,
         json=json_fixture,
         headers={"content-type": "application/json"},
     )
@@ -438,7 +438,7 @@ def test_camera_data_set_state(
     with open(f"fixtures/{json_fixture}", encoding="utf-8") as fixture_file:
         json_fixture = json.load(fixture_file)
     requests_mock.post(
-        pyatmo.camera._SETSTATE_REQ,
+        pyatmo.helpers._DEFAULT_BASE_URL + pyatmo.camera._SETSTATE_ENDPOINT,
         json=json_fixture,
         headers={"content-type": "application/json"},
     )
@@ -468,7 +468,7 @@ def test_camera_data_get_camera_picture(camera_home_data, requests_mock):
     ) as fixture_file:
         expect = fixture_file.read()
 
-    requests_mock.post(pyatmo.camera._GETCAMERAPICTURE_REQ, content=expect)
+    requests_mock.post(pyatmo.helpers._DEFAULT_BASE_URL + pyatmo.camera._GETCAMERAPICTURE_ENDPOINT, content=expect)
 
     assert camera_home_data.get_camera_picture(image_id, key) == (expect, "jpeg")
 
@@ -480,7 +480,7 @@ def test_camera_data_get_profile_image(camera_home_data, requests_mock):
     ) as fixture_file:
         expect = fixture_file.read()
 
-    requests_mock.post(pyatmo.camera._GETCAMERAPICTURE_REQ, content=expect)
+    requests_mock.post(pyatmo.helpers._DEFAULT_BASE_URL + pyatmo.camera._GETCAMERAPICTURE_ENDPOINT, content=expect)
     assert camera_home_data.get_profile_image(
         "John Doe",
         "91763b24c43d3e344f424e8b",
@@ -520,7 +520,7 @@ def test_camera_data_update_events(
     ) as fixture_file:
         json_fixture = json.load(fixture_file)
     requests_mock.post(
-        pyatmo.camera._GETEVENTSUNTIL_REQ,
+        pyatmo.helpers._DEFAULT_BASE_URL + pyatmo.camera._GETEVENTSUNTIL_ENDPOINT,
         json=json_fixture,
         headers={"content-type": "application/json"},
     )

--- a/tests/test_pyatmo_climate.py
+++ b/tests/test_pyatmo_climate.py
@@ -84,7 +84,7 @@ async def test_async_climate_update(async_climate):
     mock_home_status_resp = MockResponse(home_status_fixture, 200)
 
     with patch(
-        "pyatmo.auth.AbstractAsyncAuth.async_post_request",
+        "pyatmo.auth.AbstractAsyncAuth.async_post_api_request",
         AsyncMock(return_value=mock_home_status_resp),
     ) as mock_request:
         await async_climate.async_update()
@@ -98,7 +98,7 @@ async def test_async_climate_update(async_climate):
     mock_home_status_resp = MockResponse(home_status_fixture, 200)
 
     with patch(
-        "pyatmo.auth.AbstractAsyncAuth.async_post_request",
+        "pyatmo.auth.AbstractAsyncAuth.async_post_api_request",
         AsyncMock(return_value=mock_home_status_resp),
     ) as mock_request:
         await async_climate.async_update()
@@ -128,7 +128,7 @@ async def test_async_climate_switch_home_schedule(
         json_fixture = json.load(json_file)
 
     with patch(
-        "pyatmo.auth.AbstractAsyncAuth.async_post_request",
+        "pyatmo.auth.AbstractAsyncAuth.async_post_api_request",
         AsyncMock(return_value=json_fixture),
     ):
         with expected:
@@ -222,7 +222,7 @@ async def test_async_climate_set_thermmode(
     mock_resp = MockResponse(json_fixture, 200)
 
     with patch(
-        "pyatmo.auth.AbstractAsyncAuth.async_post_request",
+        "pyatmo.auth.AbstractAsyncAuth.async_post_api_request",
         AsyncMock(return_value=mock_resp),
     ), exception:
         res = await async_climate.async_set_thermmode(
@@ -289,7 +289,7 @@ async def test_async_climate_set_room_thermpoint(
     mock_resp = MockResponse(json_fixture, 200)
 
     with patch(
-        "pyatmo.auth.AbstractAsyncAuth.async_post_request",
+        "pyatmo.auth.AbstractAsyncAuth.async_post_api_request",
         AsyncMock(return_value=mock_resp),
     ):
         result = await async_climate.async_set_room_thermpoint(
@@ -316,7 +316,7 @@ async def test_async_climate_empty_home(async_auth, async_climate_topology):
     mock_home_status_resp = MockResponse(home_status_fixture, 200)
 
     with patch(
-        "pyatmo.auth.AbstractAsyncAuth.async_post_request",
+        "pyatmo.auth.AbstractAsyncAuth.async_post_api_request",
         AsyncMock(return_value=mock_home_status_resp),
     ):
         await climate.async_update()

--- a/tests/test_pyatmo_homecoach.py
+++ b/tests/test_pyatmo_homecoach.py
@@ -59,7 +59,7 @@ def test_home_coach_data_no_devices(auth, requests_mock):
     with open("fixtures/home_coach_no_devices.json", encoding="utf-8") as json_file:
         json_fixture = json.load(json_file)
     requests_mock.post(
-        pyatmo.home_coach._GETHOMECOACHDATA_REQ,
+        pyatmo.helpers._DEFAULT_BASE_URL + pyatmo.home_coach._GETHOMECOACHDATA_ENDPOINT,
         json=json_fixture,
         headers={"content-type": "application/json"},
     )

--- a/tests/test_pyatmo_publicdata.py
+++ b/tests/test_pyatmo_publicdata.py
@@ -16,7 +16,7 @@ def test_public_data(auth, requests_mock):
     with open("fixtures/public_data_simple.json", encoding="utf-8") as json_file:
         json_fixture = json.load(json_file)
     requests_mock.post(
-        pyatmo.public_data._GETPUBLIC_DATA,
+        pyatmo.helpers._DEFAULT_BASE_URL + pyatmo.public_data._GETPUBLIC_DATA_ENDPOINT,
         json=json_fixture,
         headers={"content-type": "application/json"},
     )
@@ -38,7 +38,7 @@ def test_public_data(auth, requests_mock):
 
 
 def test_public_data_unavailable(auth, requests_mock):
-    requests_mock.post(pyatmo.public_data._GETPUBLIC_DATA, status_code=404)
+    requests_mock.post(pyatmo.helpers._DEFAULT_BASE_URL + pyatmo.public_data._GETPUBLIC_DATA_ENDPOINT, status_code=404)
     with pytest.raises(pyatmo.ApiError):
         public_data = pyatmo.PublicData(auth, LAT_NE, LON_NE, LAT_SW, LON_SW)
         public_data.update()
@@ -48,7 +48,7 @@ def test_public_data_error(auth, requests_mock):
     with open("fixtures/public_data_error_mongo.json", encoding="utf-8") as json_file:
         json_fixture = json.load(json_file)
     requests_mock.post(
-        pyatmo.public_data._GETPUBLIC_DATA,
+        pyatmo.helpers._DEFAULT_BASE_URL + pyatmo.public_data._GETPUBLIC_DATA_ENDPOINT,
         json=json_fixture,
         headers={"content-type": "application/json"},
     )

--- a/tests/test_pyatmo_publicdata.py
+++ b/tests/test_pyatmo_publicdata.py
@@ -38,7 +38,10 @@ def test_public_data(auth, requests_mock):
 
 
 def test_public_data_unavailable(auth, requests_mock):
-    requests_mock.post(pyatmo.helpers._DEFAULT_BASE_URL + pyatmo.public_data._GETPUBLIC_DATA_ENDPOINT, status_code=404)
+    requests_mock.post(
+        pyatmo.helpers._DEFAULT_BASE_URL + pyatmo.public_data._GETPUBLIC_DATA_ENDPOINT,
+        status_code=404,
+    )
     with pytest.raises(pyatmo.ApiError):
         public_data = pyatmo.PublicData(auth, LAT_NE, LON_NE, LAT_SW, LON_SW)
         public_data.update()

--- a/tests/test_pyatmo_thermostat.py
+++ b/tests/test_pyatmo_thermostat.py
@@ -59,7 +59,7 @@ def test_home_data(home_data):
 
 def test_home_data_no_data(auth, requests_mock):
     requests_mock.post(
-        pyatmo.thermostat._GETHOMESDATA_REQ,
+        pyatmo.helpers._DEFAULT_BASE_URL + pyatmo.thermostat._GETHOMESDATA_ENDPOINT,
         json={},
         headers={"content-type": "application/json"},
     )
@@ -72,7 +72,7 @@ def test_home_data_no_body(auth, requests_mock):
     with open("fixtures/home_data_empty.json", encoding="utf-8") as json_file:
         json_fixture = json.load(json_file)
     requests_mock.post(
-        pyatmo.thermostat._GETHOMESDATA_REQ,
+        pyatmo.helpers._DEFAULT_BASE_URL + pyatmo.thermostat._GETHOMESDATA_ENDPOINT,
         json=json_fixture,
         headers={"content-type": "application/json"},
     )
@@ -85,7 +85,7 @@ def test_home_data_no_homes(auth, requests_mock):
     with open("fixtures/home_data_no_homes.json", encoding="utf-8") as json_file:
         json_fixture = json.load(json_file)
     requests_mock.post(
-        pyatmo.thermostat._GETHOMESDATA_REQ,
+        pyatmo.helpers._DEFAULT_BASE_URL + pyatmo.thermostat._GETHOMESDATA_ENDPOINT,
         json=json_fixture,
         headers={"content-type": "application/json"},
     )
@@ -98,7 +98,7 @@ def test_home_data_no_home_name(auth, requests_mock):
     with open("fixtures/home_data_nohomename.json", encoding="utf-8") as json_file:
         json_fixture = json.load(json_file)
     requests_mock.post(
-        pyatmo.thermostat._GETHOMESDATA_REQ,
+        pyatmo.helpers._DEFAULT_BASE_URL + pyatmo.thermostat._GETHOMESDATA_ENDPOINT,
         json=json_fixture,
         headers={"content-type": "application/json"},
     )
@@ -145,7 +145,7 @@ def test_home_data_switch_home_schedule(
     with open("fixtures/status_ok.json", encoding="utf-8") as json_file:
         json_fixture = json.load(json_file)
     requests_mock.post(
-        pyatmo.thermostat._SWITCHHOMESCHEDULE_REQ,
+        pyatmo.helpers._DEFAULT_BASE_URL + pyatmo.thermostat._SWITCHHOMESCHEDULE_ENDPOINT,
         json=json_fixture,
         headers={"content-type": "application/json"},
     )
@@ -211,7 +211,7 @@ def test_home_status_error_and_data(auth, requests_mock):
     ) as json_file:
         json_fixture = json.load(json_file)
     requests_mock.post(
-        pyatmo.thermostat._GETHOMESTATUS_REQ,
+        pyatmo.helpers._DEFAULT_BASE_URL + pyatmo.thermostat._GETHOMESTATUS_ENDPOINT,
         json=json_fixture,
         headers={"content-type": "application/json"},
     )
@@ -235,14 +235,14 @@ def test_home_status_error(auth, requests_mock):
     with open("fixtures/home_status_empty.json", encoding="utf-8") as json_file:
         json_fixture = json.load(json_file)
     requests_mock.post(
-        pyatmo.thermostat._GETHOMESTATUS_REQ,
+        pyatmo.helpers._DEFAULT_BASE_URL + pyatmo.thermostat._GETHOMESTATUS_ENDPOINT,
         json=json_fixture,
         headers={"content-type": "application/json"},
     )
     with open("fixtures/home_data_simple.json", encoding="utf-8") as json_file:
         json_fixture = json.load(json_file)
     requests_mock.post(
-        pyatmo.thermostat._GETHOMESDATA_REQ,
+        pyatmo.helpers._DEFAULT_BASE_URL + pyatmo.thermostat._GETHOMESDATA_ENDPOINT,
         json=json_fixture,
         headers={"content-type": "application/json"},
     )
@@ -419,7 +419,7 @@ def test_home_status_set_thermmode(
     with open(f"fixtures/{json_fixture}", encoding="utf-8") as json_file:
         json_fixture = json.load(json_file)
     requests_mock.post(
-        pyatmo.thermostat._SETTHERMMODE_REQ,
+        pyatmo.helpers._DEFAULT_BASE_URL + pyatmo.thermostat._SETTHERMMODE_ENDPOINT,
         json=json_fixture,
         headers={"content-type": "application/json"},
     )
@@ -488,7 +488,7 @@ def test_home_status_set_room_thermpoint(
     with open(f"fixtures/{json_fixture}", encoding="utf-8") as json_file:
         json_fixture = json.load(json_file)
     requests_mock.post(
-        pyatmo.thermostat._SETROOMTHERMPOINT_REQ,
+        pyatmo.helpers._DEFAULT_BASE_URL + pyatmo.thermostat._SETROOMTHERMPOINT_ENDPOINT,
         json=json_fixture,
         headers={"content-type": "application/json"},
     )
@@ -552,7 +552,7 @@ def test_home_status_set_room_thermpoint_error(
     with open(f"fixtures/{json_fixture}", encoding="utf-8") as json_file:
         json_fixture = json.load(json_file)
     requests_mock.post(
-        pyatmo.thermostat._SETROOMTHERMPOINT_REQ,
+        pyatmo.helpers._DEFAULT_BASE_URL + pyatmo.thermostat._SETROOMTHERMPOINT_ENDPOINT,
         json=json_fixture,
         headers={"content-type": "application/json"},
     )
@@ -575,14 +575,14 @@ def test_home_status_error_disconnected(
     ) as json_file:
         json_fixture = json.load(json_file)
     requests_mock.post(
-        pyatmo.thermostat._GETHOMESTATUS_REQ,
+        pyatmo.helpers._DEFAULT_BASE_URL + pyatmo.thermostat._GETHOMESTATUS_ENDPOINT,
         json=json_fixture,
         headers={"content-type": "application/json"},
     )
     with open("fixtures/home_data_simple.json", encoding="utf-8") as json_file:
         json_fixture = json.load(json_file)
     requests_mock.post(
-        pyatmo.thermostat._GETHOMESDATA_REQ,
+        pyatmo.thermostat._GETHOMESDATA_ENDPOINT,
         json=json_fixture,
         headers={"content-type": "application/json"},
     )

--- a/tests/test_pyatmo_thermostat.py
+++ b/tests/test_pyatmo_thermostat.py
@@ -145,7 +145,8 @@ def test_home_data_switch_home_schedule(
     with open("fixtures/status_ok.json", encoding="utf-8") as json_file:
         json_fixture = json.load(json_file)
     requests_mock.post(
-        pyatmo.helpers._DEFAULT_BASE_URL + pyatmo.thermostat._SWITCHHOMESCHEDULE_ENDPOINT,
+        pyatmo.helpers._DEFAULT_BASE_URL
+        + pyatmo.thermostat._SWITCHHOMESCHEDULE_ENDPOINT,
         json=json_fixture,
         headers={"content-type": "application/json"},
     )
@@ -488,7 +489,8 @@ def test_home_status_set_room_thermpoint(
     with open(f"fixtures/{json_fixture}", encoding="utf-8") as json_file:
         json_fixture = json.load(json_file)
     requests_mock.post(
-        pyatmo.helpers._DEFAULT_BASE_URL + pyatmo.thermostat._SETROOMTHERMPOINT_ENDPOINT,
+        pyatmo.helpers._DEFAULT_BASE_URL
+        + pyatmo.thermostat._SETROOMTHERMPOINT_ENDPOINT,
         json=json_fixture,
         headers={"content-type": "application/json"},
     )
@@ -552,7 +554,8 @@ def test_home_status_set_room_thermpoint_error(
     with open(f"fixtures/{json_fixture}", encoding="utf-8") as json_file:
         json_fixture = json.load(json_file)
     requests_mock.post(
-        pyatmo.helpers._DEFAULT_BASE_URL + pyatmo.thermostat._SETROOMTHERMPOINT_ENDPOINT,
+        pyatmo.helpers._DEFAULT_BASE_URL
+        + pyatmo.thermostat._SETROOMTHERMPOINT_ENDPOINT,
         json=json_fixture,
         headers={"content-type": "application/json"},
     )

--- a/tests/test_pyatmo_weatherstation.py
+++ b/tests/test_pyatmo_weatherstation.py
@@ -17,7 +17,8 @@ def test_weather_station_data(weather_station_data):
 
 def test_weather_station_data_no_response(auth, requests_mock):
     requests_mock.post(
-        pyatmo.helpers._DEFAULT_BASE_URL + pyatmo.weather_station._GETSTATIONDATA_ENDPOINT,
+        pyatmo.helpers._DEFAULT_BASE_URL
+        + pyatmo.weather_station._GETSTATIONDATA_ENDPOINT,
         json={},
         headers={"content-type": "application/json"},
     )
@@ -30,7 +31,8 @@ def test_weather_station_data_no_body(auth, requests_mock):
     with open("fixtures/status_ok.json", encoding="utf-8") as json_file:
         json_fixture = json.load(json_file)
     requests_mock.post(
-        pyatmo.helpers._DEFAULT_BASE_URL + pyatmo.weather_station._GETSTATIONDATA_ENDPOINT,
+        pyatmo.helpers._DEFAULT_BASE_URL
+        + pyatmo.weather_station._GETSTATIONDATA_ENDPOINT,
         json=json_fixture,
         headers={"content-type": "application/json"},
     )
@@ -43,7 +45,8 @@ def test_weather_station_data_no_data(auth, requests_mock):
     with open("fixtures/home_data_empty.json", encoding="utf-8") as json_file:
         json_fixture = json.load(json_file)
     requests_mock.post(
-        pyatmo.helpers._DEFAULT_BASE_URL + pyatmo.weather_station._GETSTATIONDATA_ENDPOINT,
+        pyatmo.helpers._DEFAULT_BASE_URL
+        + pyatmo.weather_station._GETSTATIONDATA_ENDPOINT,
         json=json_fixture,
         headers={"content-type": "application/json"},
     )

--- a/tests/test_pyatmo_weatherstation.py
+++ b/tests/test_pyatmo_weatherstation.py
@@ -190,7 +190,7 @@ def test_weather_station_get_station(weather_station_data):
 def test_weather_station_get_module(weather_station_data, mid, expected):
     mod = weather_station_data.get_module(mid)
 
-    assert isinstance(mod, dict) is True
+    assert isinstance(mod, dict)
     assert mod.get("_id", mod) == expected
 
 
@@ -353,8 +353,7 @@ def test_weather_station_get_last_data(
     exclude,
     expected,
 ):
-    mod = weather_station_data.get_last_data(station_id, exclude=exclude)
-    if mod:
+    if mod := weather_station_data.get_last_data(station_id, exclude=exclude):
         assert sorted(mod) == expected
     else:
         assert mod == expected
@@ -420,8 +419,7 @@ def test_weather_station_check_updated(
     delay,
     expected,
 ):
-    mod = weather_station_data.check_updated(station_id, delay)
-    if mod:
+    if mod := weather_station_data.check_updated(station_id, delay):
         assert sorted(mod) == expected
     else:
         assert mod == expected
@@ -495,8 +493,7 @@ def test_weather_station_get_last_data_bug_97(
     exclude,
     expected,
 ):
-    mod = weather_station_data.get_last_data(station_id, exclude)
-    if mod:
+    if mod := weather_station_data.get_last_data(station_id, exclude):
         assert sorted(mod) == expected
     else:
         assert mod == expected

--- a/tests/test_pyatmo_weatherstation.py
+++ b/tests/test_pyatmo_weatherstation.py
@@ -17,7 +17,7 @@ def test_weather_station_data(weather_station_data):
 
 def test_weather_station_data_no_response(auth, requests_mock):
     requests_mock.post(
-        pyatmo.weather_station._GETSTATIONDATA_REQ,
+        pyatmo.helpers._DEFAULT_BASE_URL + pyatmo.weather_station._GETSTATIONDATA_ENDPOINT,
         json={},
         headers={"content-type": "application/json"},
     )
@@ -30,7 +30,7 @@ def test_weather_station_data_no_body(auth, requests_mock):
     with open("fixtures/status_ok.json", encoding="utf-8") as json_file:
         json_fixture = json.load(json_file)
     requests_mock.post(
-        pyatmo.weather_station._GETSTATIONDATA_REQ,
+        pyatmo.helpers._DEFAULT_BASE_URL + pyatmo.weather_station._GETSTATIONDATA_ENDPOINT,
         json=json_fixture,
         headers={"content-type": "application/json"},
     )
@@ -43,7 +43,7 @@ def test_weather_station_data_no_data(auth, requests_mock):
     with open("fixtures/home_data_empty.json", encoding="utf-8") as json_file:
         json_fixture = json.load(json_file)
     requests_mock.post(
-        pyatmo.weather_station._GETSTATIONDATA_REQ,
+        pyatmo.helpers._DEFAULT_BASE_URL + pyatmo.weather_station._GETSTATIONDATA_ENDPOINT,
         json=json_fixture,
         headers={"content-type": "application/json"},
     )
@@ -440,7 +440,7 @@ def test_weather_station_get_data(
     with open("fixtures/weatherstation_measure.json", encoding="utf-8") as json_file:
         json_fixture = json.load(json_file)
     requests_mock.post(
-        pyatmo.weather_station._GETMEASURE_REQ,
+        pyatmo.helpers._DEFAULT_BASE_URL + pyatmo.weather_station._GETMEASURE_ENDPOINT,
         json=json_fixture,
         headers={"content-type": "application/json"},
     )

--- a/usage.md
+++ b/usage.md
@@ -103,11 +103,9 @@ The results are Python data structures, mostly dictionaries as they mirror easil
 
 #### 4-1 Global variables
 
-```python
-_BASE_URL and _*_REQ : Various URL to access Netatmo web services. They are
-documented in http://dev.netatmo.com/doc/ They should not be changed unless
-Netatmo API changes.
-```
+`_DEFAULT_BASE_URL` and `_*_REQ`: Various URL to access Netatmo web services. 
+They are documented in https://dev.netatmo.com/doc/.
+They should not be changed unless Netatmo API changes.
 
 #### 4-2 ClientAuth class
 
@@ -120,6 +118,8 @@ authorization = pyatmo.ClientAuth(
     username=USERNAME,
     password=PASSWORD,
     scope="read_station",
+    base_url="https://example.com/api",  #optional
+    user_prefix="xmpl",                  #optional
 )
 ```
 
@@ -132,6 +132,8 @@ Properties, all properties are read-only unless specified :
 - **accessToken** : Retrieve a valid access token (renewed if necessary)
 - **refreshToken** : The token used to renew the access token (normally should not be used)
 - **expiration** : The expiration time (epoch) of the current token
+- **base_url** : If targeting a third-party Netatmo-compatible API, the custom base URL to reach it
+- **user_prefix** : If targeting a third-part Netatmo-compatible API, the custom user prefix for this API
 - **scope** : The scope of the required access token (what will it be used for) default to read_station to provide backward compatibility.
 
 Possible values for scope are :

--- a/usage.md
+++ b/usage.md
@@ -103,7 +103,7 @@ The results are Python data structures, mostly dictionaries as they mirror easil
 
 #### 4-1 Global variables
 
-`_DEFAULT_BASE_URL` and `_*_REQ`: Various URL to access Netatmo web services. 
+`_DEFAULT_BASE_URL` and `_*_REQ`: Various URL to access Netatmo web services.
 They are documented in https://dev.netatmo.com/doc/.
 They should not be changed unless Netatmo API changes.
 


### PR DESCRIPTION
This PR aims to close #157 by adding third-party API support to the library.

Some thermostat manufacturers such as Muller-Intuitiv and Saunier-Duval seem to be selling Netatmo products under their own brand. These products don't have the exact same functionality and ship with their own applications -- which can be, let's say, quite limited. However, these apps still rely on a Netatmo-compatible API.

To be able to call these APIs from `pyatmo`, two changes must be made to the library:
- Make the base URL configurable, currently hard-coded to `https://api.netatmo.com/`
- Add support for a `user_prefix` URL query parameter during authentication, which seems to be a hint to the Netatmo auth backend to silo their different user bases.

To this end, in this PR, we:
- Rename `_BASE_URL` to `_DEFAULT_BASE_URL` ;
- Add `user_prefix` and `base_url` as optional, configurable parameters to the auth structure;
- Add `post_api_request` function which takes an endpoint and automatically appends the configured base url (same for the async variant)