### PR TITLE
Catch ClientConnectorError during camera url update

### DIFF
--- a/src/pyatmo/camera.py
+++ b/src/pyatmo/camera.py
@@ -666,7 +666,7 @@ class AsyncCameraData(AbstractCameraData):
             await self._async_update_all_camera_urls()
         except (aiohttp.ContentTypeError, aiohttp.ClientConnectorError) as err:
             LOG.debug("One or more camera could not be reached. (%s)", err)
-            
+
         self._store_last_event()
 
     async def _async_update_all_camera_urls(self) -> None:

--- a/src/pyatmo/camera.py
+++ b/src/pyatmo/camera.py
@@ -666,6 +666,7 @@ class AsyncCameraData(AbstractCameraData):
             await self._async_update_all_camera_urls()
         except (aiohttp.ContentTypeError, aiohttp.ClientConnectorError) as err:
             LOG.debug("One or more camera could not be reached. (%s)", err)
+            
         self._store_last_event()
 
     async def _async_update_all_camera_urls(self) -> None:

--- a/src/pyatmo/camera.py
+++ b/src/pyatmo/camera.py
@@ -664,10 +664,8 @@ class AsyncCameraData(AbstractCameraData):
 
         try:
             await self._async_update_all_camera_urls()
-        except aiohttp.ContentTypeError as err:
+        except (aiohttp.ContentTypeError, aiohttp.ClientConnectorError) as err:
             LOG.debug("One or more camera could not be reached. (%s)", err)
-        except aiohttp.ClientConnectorError as err:
-            LOG.debug("One or more camera could not be reached (network unreacheable). (%s)", err)
         self._store_last_event()
 
     async def _async_update_all_camera_urls(self) -> None:

--- a/src/pyatmo/camera.py
+++ b/src/pyatmo/camera.py
@@ -666,7 +666,8 @@ class AsyncCameraData(AbstractCameraData):
             await self._async_update_all_camera_urls()
         except aiohttp.ContentTypeError as err:
             LOG.debug("One or more camera could not be reached. (%s)", err)
-
+        except aiohttp.ClientConnectorError as err:
+            LOG.debug("One or more camera could not be reached (network unreacheable). (%s)", err)
         self._store_last_event()
 
     async def _async_update_all_camera_urls(self) -> None:


### PR DESCRIPTION
When _async_update_all_camera_urls is called, it could request an IP not authorized anymore by the network.
It will create a ClientConnectorError exception which needs to be caught.

E.g.:
File "/usr/local/lib/python3.10/site-packages/aiohttp/connector.py", line 992, in _wrap_create_connection
    raise client_error(req.connection_key, exc) from exc
aiohttp.client_exceptions.ClientConnectorError: Cannot connect to host 192.168.1.136:80 ssl:default [Connect call failed ('192.168.1.136', 80)]
