### PR TITLE
wrap mapped zones with list

### DIFF
--- a/src/pyatmo/schedule.py
+++ b/src/pyatmo/schedule.py
@@ -36,7 +36,7 @@ class Schedule(NetatmoBase):
                 raw_data.get("timetable", []),
             ),
         )
-        self.zones = map(lambda r: Zone(home, r), raw_data.get("zones", []))
+        self.zones = list(map(lambda r: Zone(home, r), raw_data.get("zones", [])))
 
 
 @dataclass


### PR DESCRIPTION
There was a small bug in my previously submitted PR. The attribute `zones` needs to be a list in order to be reused when making changes to the schedule.